### PR TITLE
Fix warnings

### DIFF
--- a/lib/broccoli/glimmer-app.js
+++ b/lib/broccoli/glimmer-app.js
@@ -9,7 +9,7 @@ var Funnel = require('broccoli-funnel');
 var fs = require('fs');
 var path = require('path');
 var rimraf = require('rimraf');
-var typescript = require('broccoli-typescript-compiler');
+var typescript = require('broccoli-typescript-compiler').typescript;
 var concat = require('broccoli-concat');
 var merge = require('broccoli-merge-trees');
 var stew = require('broccoli-stew');
@@ -89,36 +89,41 @@ GlimmerApp.prototype.toTree = function(options) {
         moduleResolution: "node",
         rootDir: '.',
         mapRoot : '/'
-      }
+      },
+      include: [
+        'src/**/*.ts'
+      ],
+      exclude: [
+        'node_modules',
+        '**/*.d.ts'
+      ]
     }
   };
 
   // Select all app src, except config file that needs to be rewritten
-  var tsTree = find(app, {
-    include: ['**/*.ts'],
-    exclude: ['**/*.d.ts', 'config/**/*.ts']
+  var jsTree = find(typescript(projectDir, tsOptions), {
+    srcDir: 'src',
+    exclude: ['config']
   });
 
-  var resolvableTree = find(app, {
-    include: ['**/*.ts', '**/*.hbs'],
-    exclude: ['**/*.d.ts', 'config/**/*.ts']
+  var resolvableTree = find(jsTree, {
+    include: ['**/*.js', '**/*.hbs'],
+    exclude: ['**/*.d.js', 'config']
   });
 
   var configEnvironment = find(app, {
     include: ['config/environment.ts']
   });
 
-var moduleMap = this.buildModuleMap(resolvableTree, configEnvironment);
+  var moduleMap = this.buildModuleMap(resolvableTree, configEnvironment);
 
   configEnvironment = this.rewriteConfigEnvironment(configEnvironment);
 
-  tsTree = merge([
-    tsTree,
+  jsTree = merge([
+    jsTree,
     moduleMap,
     configEnvironment
   ]);
-
-  var jsTree = typescript(tsTree, tsOptions);
 
   var hbsTree = find([ app ], {
     include: [

--- a/lib/broccoli/glimmer-app.js
+++ b/lib/broccoli/glimmer-app.js
@@ -100,19 +100,26 @@ GlimmerApp.prototype.toTree = function(options) {
     }
   };
 
-  // Select all app src, except config file that needs to be rewritten
-  var jsTree = find(typescript(projectDir, tsOptions), {
+  var compiledTS = typescript(projectDir, tsOptions);
+
+  var jsTree = find(compiledTS, {
     srcDir: 'src',
-    exclude: ['config']
+    exclude: ['config/**/*', '**/*.d.ts']
   });
 
-  var resolvableTree = find(jsTree, {
+  var hbsTree = find(projectDir, {
+    include: ['src/**/*.hbs']
+  });
+
+  var resolvableTree = find([compiledTS, hbsTree], {
+    srcDir: 'src',
     include: ['**/*.js', '**/*.hbs'],
-    exclude: ['**/*.d.js', 'config']
+    exclude: ['config/**/*']
   });
 
-  var configEnvironment = find(app, {
-    include: ['config/environment.ts']
+  var configEnvironment = find(compiledTS, {
+    srcDir: 'src',
+    include: ['config/environment.js']
   });
 
   var moduleMap = this.buildModuleMap(resolvableTree, configEnvironment);
@@ -125,10 +132,8 @@ GlimmerApp.prototype.toTree = function(options) {
     configEnvironment
   ]);
 
-  var hbsTree = find([ app ], {
-    include: [
-      '**/*.hbs'
-    ]
+  hbsTree = find(hbsTree, {
+    srcDir: 'src'
   });
 
   hbsTree = new GlimmerTemplatePrecompiler(hbsTree, {
@@ -212,7 +217,7 @@ GlimmerApp.prototype._configPath = function() {
 GlimmerApp.prototype.rewriteConfigEnvironment = function(src) {
   return new ConfigReplace(src, this._configTree(), {
     configPath: this._configPath(),
-    files: [ 'config/environment.ts' ],
+    files: [ 'config/environment.js' ],
     patterns: this._configReplacePatterns()
   });
 }

--- a/lib/broccoli/module-map-creator.js
+++ b/lib/broccoli/module-map-creator.js
@@ -96,7 +96,7 @@ ModuleMapCreator.prototype.build = function() {
   var contents = moduleImports.join('\n') + '\n' +
     "export default moduleMap = {" + mapContents.join(',') + "};" + '\n';
 
-  fs.writeFileSync(path.join(this.outputPath, 'config', 'module-map.ts'), contents, { encoding: 'utf8' });
+  fs.writeFileSync(path.join(this.outputPath, 'config', 'module-map.js'), contents, { encoding: 'utf8' });
 };
 
 module.exports = ModuleMapCreator;

--- a/lib/broccoli/rollup-with-dependencies.js
+++ b/lib/broccoli/rollup-with-dependencies.js
@@ -26,7 +26,15 @@ RollupWithDependencies.prototype.build = function() {
   plugins.push(sourcemaps());
 
   plugins.push(babel({
-    presets: 'es2015-rollup',
+    presets: [
+      [
+        'es2015',
+        { modules: false }
+      ]
+    ],
+    plugins: [
+      'external-helpers'
+    ],
     // TODO sourceMaps: 'inline',
     retainLines: true
   }));

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "@glimmer/compiler": "^0.21.1",
     "@glimmer/di": "^0.1.8",
-    "babel-preset-es2015-rollup": "^1.2.0",
+    "babel-plugin-external-helpers": "^6.22.0",
+    "babel-preset-es2015": "^6.22.0",
     "broccoli-asset-rev": "^2.4.3",
     "broccoli-babel-transpiler": "next",
     "broccoli-caching-writer": "^2.2.1",
@@ -28,7 +29,7 @@
     "handlebars": "^4.0.5",
     "rimraf": "^2.5.4",
     "rollup": "^0.36.4",
-    "rollup-plugin-babel": "^2.6.1",
+    "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-node-resolve": "^2.0.0",
     "rollup-plugin-sourcemaps": "^0.4.1",
     "typescript": "^2.1.5",


### PR DESCRIPTION
- [x] Include `node_modules` in TypeScript build
- [x] Use "new" [Babel config](https://github.com/rollup/rollup-plugin-babel#configuring-babel) for Rollup
- [x] Make hello-glimmer boot without runtime errors