### PR TITLE
Fix rebuild, allow js files in source

### DIFF
--- a/lib/broccoli/glimmer-app.js
+++ b/lib/broccoli/glimmer-app.js
@@ -90,9 +90,6 @@ GlimmerApp.prototype.toTree = function(options) {
         rootDir: '.',
         mapRoot : '/'
       },
-      include: [
-        'src/**/*.ts'
-      ],
       exclude: [
         'node_modules',
         '**/*.d.ts'
@@ -100,11 +97,21 @@ GlimmerApp.prototype.toTree = function(options) {
     }
   };
 
-  var compiledTS = typescript(projectDir, tsOptions);
+  var srcTree = find(app, {
+    destDir: 'src'
+  });
+
+  var nodeModules = find(path.join(projectDir, 'node_modules'), {
+    destDir: 'node_modules'
+  });
+
+  var tsTree = merge([srcTree, nodeModules]);
+
+  var compiledTS = typescript(tsTree, tsOptions);
 
   var jsTree = find(compiledTS, {
     srcDir: 'src',
-    exclude: ['config/**/*', '**/*.d.ts']
+    exclude: ['config/**', '**/*.d.ts']
   });
 
   var hbsTree = find(projectDir, {
@@ -114,7 +121,7 @@ GlimmerApp.prototype.toTree = function(options) {
   var resolvableTree = find([compiledTS, hbsTree], {
     srcDir: 'src',
     include: ['**/*.js', '**/*.hbs'],
-    exclude: ['config/**/*']
+    exclude: ['config/**']
   });
 
   var configEnvironment = find(compiledTS, {

--- a/lib/broccoli/glimmer-app.js
+++ b/lib/broccoli/glimmer-app.js
@@ -86,9 +86,7 @@ GlimmerApp.prototype.toTree = function(options) {
         module: "es2015",
         inlineSourceMap: true,
         inlineSources: true,
-        moduleResolution: "node",
-        rootDir: '.',
-        mapRoot : '/'
+        moduleResolution: "node"
       },
       exclude: [
         'node_modules',

--- a/lib/broccoli/glimmer-app.js
+++ b/lib/broccoli/glimmer-app.js
@@ -71,9 +71,9 @@ GlimmerApp.prototype.appConstructor = EmberApp.prototype.constructor;
 GlimmerApp.prototype.toTree = function(options) {
   var projectDir = process.cwd();
   var projectFolder = this.projectFolder = (options && options.projectFolder || 'src');
-  var app = projectDir + '/' + projectFolder;
+  var srcDir = projectDir + '/' + projectFolder;
 
-  console.log('Building app tree:', app);
+  console.log('Building app tree:', srcDir);
 
   if (process.env.EMBER_ENV !== 'production') {
     rimraf.sync('dist');
@@ -97,8 +97,12 @@ GlimmerApp.prototype.toTree = function(options) {
     }
   };
 
-  var srcTree = find(app, {
+  var srcTree = find(srcDir, {
     destDir: 'src'
+  });
+
+  var tsBypassTree = find(srcTree, {
+    include: ['**/*.js']
   });
 
   var nodeModules = find(path.join(projectDir, 'node_modules'), {
@@ -109,7 +113,9 @@ GlimmerApp.prototype.toTree = function(options) {
 
   var compiledTS = typescript(tsTree, tsOptions);
 
-  var jsTree = find(compiledTS, {
+  var appTree = merge([compiledTS, tsBypassTree]);
+
+  var jsTree = find(appTree, {
     srcDir: 'src',
     exclude: ['config/**', '**/*.d.ts']
   });
@@ -118,13 +124,13 @@ GlimmerApp.prototype.toTree = function(options) {
     include: ['src/**/*.hbs']
   });
 
-  var resolvableTree = find([compiledTS, hbsTree], {
+  var resolvableTree = find([appTree, hbsTree], {
     srcDir: 'src',
     include: ['**/*.js', '**/*.hbs'],
     exclude: ['config/**']
   });
 
-  var configEnvironment = find(compiledTS, {
+  var configEnvironment = find(appTree, {
     srcDir: 'src',
     include: ['config/environment.js']
   });
@@ -180,7 +186,7 @@ GlimmerApp.prototype.toTree = function(options) {
 
   var htmlTree = this.index();
 
-  var cssTree = compileSass([app + '/ui/styles'],
+  var cssTree = compileSass([srcDir + '/ui/styles'],
                             'app.scss', 'app.css');
 
   var appTree = merge([


### PR DESCRIPTION
`ember-cli` rebuild was breaking because the `tmp` dir was making it into the TypeScript compiler. This explicitly selects the `src` dir (which remains configurable) and the `node_modules` dir.

I also snuck in a js bypass since the TypeScript compiler clobbers any js files.