### PR TITLE
Fix suppression of THIS_IS_UNDEFINED rollup warning

### DIFF
--- a/lib/broccoli/rollup-with-dependencies.ts
+++ b/lib/broccoli/rollup-with-dependencies.ts
@@ -39,13 +39,13 @@ class RollupWithDependencies extends Rollup {
 
     this.rollupOptions.plugins = plugins;
 
-    this.rollupOptions.onwarn = function(message) {
+    this.rollupOptions.onwarn = function(warning) {
       // Suppress known error message caused by TypeScript compiled code with Rollup
       // https://github.com/rollup/rollup/wiki/Troubleshooting#this-is-undefined
-      if (/The \`this\` keyword is equivalent to \`undefined\` at the top level of an ES module, and has been rewritten/.test(message)) {
+      if (warning.code === 'THIS_IS_UNDEFINED') {
         return;
       }
-      console.log("Rollup warning: ", message);
+      console.log("Rollup warning: ", warning.message);
     };
 
     return Rollup.prototype.build.apply(this, args);

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "heimdalljs-logger": "^0.1.8",
     "lodash.defaultsdeep": "^4.6.0",
     "rimraf": "^2.5.4",
-    "rollup": "^0.36.4",
+    "rollup": "^0.41.6",
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-node-resolve": "^2.0.0",
     "walk-sync": "^0.3.1"


### PR DESCRIPTION
This warning is common when rolling up TypeScript compiled code, esp. when using generators.

See https://github.com/rollup/rollup/issues/794#issuecomment-270803587