### PR TITLE
Support for `content-for` replacements, including live-reload

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "dependencies": {
-    "@glimmer/compiler": "0.23.0-alpha.6",
-    "@glimmer/di": "^0.1.8",
+    "@glimmer/compiler": "0.23.0-alpha.7",
+    "@glimmer/di": "^0.2.0",
     "@glimmer/resolution-map-builder": "^0.1.0",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-preset-es2015": "^6.22.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "broccoli-string-replace": "^0.1.1",
     "broccoli-typescript-compiler": "^1.0.1",
     "broccoli-uglify-sourcemap": "^1.4.0",
+    "ember-cli-inject-live-reload": "^1.4.1",
     "handlebars": "^4.0.5",
     "heimdalljs-logger": "^0.1.8",
     "lodash.defaultsdeep": "^4.6.0",


### PR DESCRIPTION
In order to support live-reload, we need to allow the ember-cli-inject-live-reload addon to insert content in an app's `index.html`.

Now that `GlimmerApp` no longer extends `EmberApp`, it was necessary to bring over the `content-for` replacement mechanism. This allows for extensible custom content in the page head and body.

In order to work properly, the blueprint for `index.html` will need `{{content-for "head"}}` added (PR incoming).

