### PR TITLE
use correct casing for lodash.defaultsdeep

### DIFF
--- a/src/broccoli/glimmer-app.ts
+++ b/src/broccoli/glimmer-app.ts
@@ -1,4 +1,4 @@
-import defaultsDeep from 'lodash.defaultsDeep';
+import defaultsDeep from 'lodash.defaultsdeep';
 
 import ConfigLoader from 'broccoli-config-loader';
 import ConfigReplace from 'broccoli-config-replace';


### PR DESCRIPTION
OSX has a case-insensitive filesystem by default, but linux does has a case-sensitive filesystem. This gets this working on Linux and Windows.

Here is the original package: https://www.npmjs.com/package/lodash.defaultsdeep