### PR TITLE
Fix style support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 
 node_js:
-  - "4"
   - "6"
   - "node"

--- a/testem.json
+++ b/testem.json
@@ -3,5 +3,5 @@
   "test_page": "index.html",
   "src_files": ["src/**/*", "test/**/*"],
   "disable_watching": true,
-  "launch_in_ci": ["Firefox"]
+  "launch_in_ci": ["phantomjs"]
 }


### PR DESCRIPTION
SASS will be compiled if `src/ui/styles/app.scss` is present.

Otherwise, all CSS in `src/ui/styles` will be concat’d.

This is preliminary, but should be safe, and is compatible with
Module Unification. We’re not taking a stance on colocation (yet).