### PR TITLE
Fix `{{rootURL}}` support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "broccoli-test-helper": "^1.1.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
+    "common-tags": "^1.4.0",
     "ember-cli": "2.13.0-beta.2",
     "ember-cli-blueprint-test-helpers": "^0.17.1",
     "mocha": "^3.2.0",

--- a/src/broccoli/glimmer-app.ts
+++ b/src/broccoli/glimmer-app.ts
@@ -133,7 +133,7 @@ export default class GlimmerApp {
   _configReplacePatterns() {
     return [{
       match: /\{\{rootURL\}\}/g,
-      replacement: () => '',
+      replacement: (config) => config.rootURL || '',
     }, {
       match: /\{\{content-for ['"](.+)["']\}\}/g,
       replacement: this.contentFor.bind(this)

--- a/tests/broccoli/glimmer-app-test.ts
+++ b/tests/broccoli/glimmer-app-test.ts
@@ -7,6 +7,8 @@ const createTempDir = broccoliTestHelper.createTempDir;
 const MockCLI = require('ember-cli/tests/helpers/mock-cli');
 const Project = require('ember-cli/lib/models/project');
 
+const { stripIndent } = require('common-tags');
+
 const GlimmerApp = require('../../src').GlimmerApp;
 
 const expect = require('../helpers/chai').expect;
@@ -50,6 +52,40 @@ describe('glimmer-app', function() {
 
       expect(output.read()).to.deep.equal({
         'index.html': 'src',
+      });
+    });
+
+    it('updates rootURL from config', async function () {
+      input.write({
+        'app': {},
+        'src': {
+          'ui': {
+            'index.html': stripIndent`
+              <body>
+               <head>
+                 <script src="{{rootURL}}bar.js"></script>
+               </head>
+              </body>`,
+          },
+        },
+        'config': {
+          'environment.js': `
+            module.exports = function() {
+              return { rootURL: '/foo/' };
+            };`
+        },
+      });
+
+      let app = createApp();
+      let output = await buildOutput(app.htmlTree());
+
+      expect(output.read()).to.deep.equal({
+        'index.html': stripIndent`
+              <body>
+               <head>
+                 <script src="/foo/bar.js"></script>
+               </head>
+              </body>`
       });
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1644,6 +1644,12 @@ commander@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.1.0.tgz#d121bbae860d9992a3d517ba96f56588e47c6781"
 
+common-tags@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.4.0.tgz#1187be4f3d4cf0c0427d43f74eef1f73501614c0"
+  dependencies:
+    babel-runtime "^6.18.0"
+
 commoner@~0.10.3:
   version "0.10.8"
   resolved "https://registry.yarnpkg.com/commoner/-/commoner-0.10.8.tgz#34fc3672cd24393e8bb47e70caa0293811f4f2c5"


### PR DESCRIPTION
Should be rebased and land after https://github.com/glimmerjs/glimmer-application-pipeline/pull/49.

See the last two commits here for the commits related to this PR...