### PR TITLE
Make testing nicer...

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "preversion": "npm test",
     "prepublish": "npm run build",
     "postpublish": "git push origin master --tags",
-    "pretest": "ember build",
-    "test": "mocha dist/tests --recursive"
+    "test": "ember test",
+    "start": "ember test --server"
   },
   "repository": "https://github.com/glimmerjs/glimmer-application-pipeline",
   "license": "MIT",

--- a/testem.js
+++ b/testem.js
@@ -1,0 +1,11 @@
+module.exports = {
+  disable_watching: true,
+  launch_in_ci: ['Mocha'],
+  launch_in_dev: ['Mocha'],
+  launchers: {
+    Mocha: {
+      command: "mocha dist/tests --recursive --reporter tap",
+      protocol: 'tap'
+    }
+  }
+};

--- a/testem.json
+++ b/testem.json
@@ -1,7 +1,0 @@
-{
-  "framework": "qunit",
-  "test_page": "index.html",
-  "src_files": ["lib/**/*", "test/**/*"],
-  "disable_watching": true,
-  "launch_in_ci": ["phantomjs"]
-}


### PR DESCRIPTION
Allows using `yarn start` or `npm start` to kick off an automatically
rebuilding `testem` session.