### PR TITLE
Throw errors for invalid constructor arguments.

### DIFF
--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -111,12 +111,17 @@ export default class GlimmerApp {
   protected srcPath: string;
 
   constructor(defaults, options) {
+    let missingProjectMessage = 'You must pass through the default arguments passed into your ember-cli-build.js file when constructing a new GlimmerApp';
     if (arguments.length === 0) {
-      options = {};
+      throw new Error(missingProjectMessage);
     } else if (arguments.length === 1) {
       options = defaults;
     } else {
       defaultsDeep(options, defaults);
+    }
+
+    if (!options.project) {
+      throw new Error(missingProjectMessage);
     }
 
     options = this.options = defaultsDeep(options, DEFAULT_CONFIG);

--- a/tests/broccoli/glimmer-app-test.ts
+++ b/tests/broccoli/glimmer-app-test.ts
@@ -35,6 +35,20 @@ describe('glimmer-app', function() {
     }, options);
   }
 
+  describe('constructor', function() {
+    it('throws an error if no arguments are provided', function() {
+      expect(() => {
+        new GlimmerApp();
+      }).to.throw(/must pass through the default arguments/)
+    });
+
+    it('throws an error if project is not passed through', function() {
+      expect(() => {
+        new GlimmerApp({});
+      }).to.throw(/must pass through the default arguments/)
+    });
+  });
+
   describe('htmlTree', function() {
     it('emits index.html', async function () {
       input.write({


### PR DESCRIPTION
If the `defaults` argument from `ember-cli` (first arg passed into
the `ember-cli-build.js` function) is missing, throw an error.

We require the `project` to be present, this helps ensure that it is.