### PR TITLE
More tests and refactorings.

### DIFF
--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -16,14 +16,15 @@ const assetRev = require('broccoli-asset-rev');
 const uglify = require('broccoli-uglify-sourcemap');
 const ResolutionMapBuilder = require('@glimmer/resolution-map-builder');
 const ResolverConfigurationBuilder = require('@glimmer/resolver-configuration-builder');
-const RollupWithDependencies = require('./rollup-with-dependencies');
-const GlimmerTemplatePrecompiler = require('./glimmer-template-precompiler');
-const defaultModuleConfiguration = require('./default-module-configuration');
 const BroccoliSource = require('broccoli-source');
 const WatchedDir = BroccoliSource.WatchedDir;
 const UnwatchedDir = BroccoliSource.UnwatchedDir;
 
-const Logger = require('heimdalljs-logger');
+import RollupWithDependencies from './rollup-with-dependencies';
+import GlimmerTemplatePrecompiler from './glimmer-template-precompiler';
+import defaultModuleConfiguration from './default-module-configuration';
+
+//const Logger = require('heimdalljs-logger');
 //const logger = Logger('@glimmer/application-pipeline:glimmer-app');
 
 const stew  = require('broccoli-stew');

--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -39,13 +39,10 @@ const DEFAULT_CONFIG = {
     }
   },
   configPath: './config/environment',
-  trees: {
-    app: 'src',
-    styles: 'src/ui/styles'
-  },
+  trees: { },
   jshintrc: {
     tests: 'tests',
-    app: 'src'
+    src: 'src'
   }
 };
 
@@ -92,8 +89,8 @@ export interface Project {
 }
 
 export interface Trees {
-  srcTree: Tree;
-  nodeModulesTree: Tree;
+  src: Tree;
+  nodeModules: Tree;
 }
 
 export interface Tree {
@@ -171,8 +168,8 @@ export default class GlimmerApp {
     });
 
     return {
-      srcTree,
-      nodeModulesTree
+      src: srcTree,
+      nodeModules: nodeModulesTree
     }
   }
 
@@ -240,16 +237,11 @@ export default class GlimmerApp {
   }
 
   private javascriptTree() {
-    let { srcTree, nodeModulesTree } = this.trees;
-
-    // Grab the app's `src` directory.
-    srcTree = find(srcTree, {
-      destDir: 'src'
-    });
+    let { src, nodeModules } = this.trees;
 
     // Compile the TypeScript and Handlebars files into JavaScript
-    const compiledHandlebarsTree = this.compiledHandlebarsTree(srcTree);
-    const compiledTypeScriptTree = this.compiledTypeScriptTree(srcTree, nodeModulesTree)
+    const compiledHandlebarsTree = this.compiledHandlebarsTree(src);
+    const compiledTypeScriptTree = this.compiledTypeScriptTree(src, nodeModules)
 
     // Remove top-most `src` directory so module names don't include it.
     const resolvableTree = find(merge([compiledTypeScriptTree, compiledHandlebarsTree]), {
@@ -382,17 +374,17 @@ export default class GlimmerApp {
   }
 
   private htmlTree() {
-    let srcTree = this.trees.srcTree;
+    let srcTree = this.trees.src;
 
     const htmlName = this.options.outputPaths.app.html;
     const files = [
-      'ui/index.html'
+      'src/ui/index.html'
     ];
 
     const index = new Funnel(srcTree, {
       files,
       getDestinationPath(relativePath) {
-        if (relativePath === 'ui/index.html') {
+        if (relativePath === 'src/ui/index.html') {
           relativePath = htmlName;
         }
         return relativePath;

--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -146,8 +146,20 @@ export default class GlimmerApp {
   }
 
   private buildTrees(): Trees {
-    const srcPath = this.resolveLocal('src');
-    const srcTree = existsSync(srcPath) ? new WatchedDir(srcPath) : null;
+    let srcTree = this.options.trees.src;
+
+    if (typeof srcTree === 'string') {
+      srcTree = new WatchedDir(this.resolveLocal(srcTree));
+    } else if (!srcTree) {
+      let srcPath = this.resolveLocal('src');
+      srcTree = existsSync(srcPath) ? new WatchedDir(srcPath) : null;
+    }
+
+    if (srcTree) {
+      srcTree = new Funnel(srcTree, {
+        destDir: 'src'
+      });
+    }
 
     const nodeModulesTree = new Funnel(new UnwatchedDir(this.project.root), {
       srcDir: 'node_modules/@glimmer',

--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -116,7 +116,6 @@ export default class GlimmerApp {
   public env: 'production' | 'development' | 'test';
 
   protected trees: Trees;
-  protected srcPath: string;
 
   constructor(defaults: EmberCLIDefaults, options: GlimmerAppOptions = {}) {
     let missingProjectMessage = 'You must pass through the default arguments passed into your ember-cli-build.js file when constructing a new GlimmerApp';
@@ -134,9 +133,6 @@ export default class GlimmerApp {
     this.project = defaults.project;
     this.name = this.project.name();
     this.trees = this.buildTrees();
-
-    let srcPath = options.srcPath || 'src';
-    this.srcPath = this.resolveLocal(srcPath);
   }
 
   private _configReplacePatterns() {
@@ -339,7 +335,11 @@ export default class GlimmerApp {
   }
 
   private cssTree() {
-    let stylesPath = path.join(this.srcPath, 'ui', 'styles');
+    // should really make SASS support to be opt-in, so that
+    // we can properly honor the `GlimmerAppOptions.trees.src`
+    // abstraction here, but for now we still require `src` to be a
+    // "real" path on disk that we check
+    let stylesPath = path.join(this.resolveLocal('src'), 'ui', 'styles');
 
     if (fs.existsSync(stylesPath)) {
       // Compile SASS if app.scss is present

--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -64,8 +64,15 @@ const DEFAULT_TS_OPTIONS = {
   }
 };
 
+export interface EmberCLIDefaults {
+  project: Project
+}
+
 export interface GlimmerAppOptions {
-  outputPaths: any;
+  outputPaths?: any;
+  trees?: {
+    src?: string | Tree
+  }
 }
 
 export interface Addon {
@@ -110,25 +117,21 @@ export default class GlimmerApp {
   protected trees: Trees;
   protected srcPath: string;
 
-  constructor(defaults, options) {
+  constructor(defaults: EmberCLIDefaults, options: GlimmerAppOptions = {}) {
     let missingProjectMessage = 'You must pass through the default arguments passed into your ember-cli-build.js file when constructing a new GlimmerApp';
     if (arguments.length === 0) {
       throw new Error(missingProjectMessage);
-    } else if (arguments.length === 1) {
-      options = defaults;
-    } else {
-      defaultsDeep(options, defaults);
     }
 
-    if (!options.project) {
+    if (!defaults.project) {
       throw new Error(missingProjectMessage);
     }
 
     options = this.options = defaultsDeep(options, DEFAULT_CONFIG);
 
     this.env = process.env.EMBER_ENV || 'development';
-    this.project = options.project;
-    this.name = options.name || this.project.name();
+    this.project = defaults.project;
+    this.name = this.project.name();
     this.trees = this.buildTrees();
 
     let srcPath = options.srcPath || 'src';

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "preversion": "npm test",
     "prepublish": "npm run build",
     "postpublish": "git push origin master --tags",
-    "test": "ember test",
+    "pretest": "ember build",
+    "test": "mocha dist/tests --recursive",
     "start": "ember test --server"
   },
   "repository": "https://github.com/glimmerjs/glimmer-application-pipeline",

--- a/tests/broccoli/glimmer-app-test.ts
+++ b/tests/broccoli/glimmer-app-test.ts
@@ -136,6 +136,35 @@ describe('glimmer-app', function() {
               </body>`
       });
     });
+
+    it('allows passing custom `src` tree', async function () {
+      input.write({
+        'app': {},
+        'derp': {
+          'ui': {
+            'index.html': 'derp'
+          }
+        },
+        'src': {
+          'ui': {
+            'index.html': 'src',
+          },
+        },
+        'config': {},
+      });
+
+      let app = createApp({
+        trees: {
+          src: 'derp'
+        }
+      }) as any;
+
+      let output = await buildOutput(app.htmlTree());
+
+      expect(output.read()).to.deep.equal({
+        'index.html': 'derp',
+      });
+    });
   });
 
   describe('cssTree', function() {

--- a/tests/broccoli/glimmer-app-test.ts
+++ b/tests/broccoli/glimmer-app-test.ts
@@ -47,6 +47,38 @@ describe('glimmer-app', function() {
         new GlimmerApp({});
       }).to.throw(/must pass through the default arguments/)
     });
+
+    describe('env', function() {
+      const ORIGINAL_EMBER_ENV = process.env.EMBER_ENV;
+
+      beforeEach(function() {
+        delete process.env.EMBER_ENV;
+      });
+
+      afterEach(function() {
+        process.env.EMBER_ENV = ORIGINAL_EMBER_ENV;
+      });
+
+      it('sets an `env`', function() {
+        let app = createApp();
+
+        expect(app.env).to.be.defined;
+      })
+
+      it('sets an `env` to `development` if process.env.EMBER_ENV is undefined', function() {
+        let app = createApp();
+
+        expect(app.env).to.equal('development');
+      })
+
+      it('sets an `env` to process.env.EMBER_ENV if present', function() {
+        process.env.EMBER_ENV = 'test';
+
+        let app = createApp();
+
+        expect(app.env).to.equal('test');
+      })
+    })
   });
 
   describe('htmlTree', function() {

--- a/tests/broccoli/glimmer-app-test.ts
+++ b/tests/broccoli/glimmer-app-test.ts
@@ -9,7 +9,7 @@ const Project = require('ember-cli/lib/models/project');
 
 const { stripIndent } = require('common-tags');
 
-const GlimmerApp = require('../../lib').GlimmerApp;
+import GlimmerApp, { GlimmerAppOptions } from '../../lib/broccoli/glimmer-app';
 
 const expect = require('../helpers/chai').expect;
 
@@ -24,7 +24,7 @@ describe('glimmer-app', function() {
     return input.dispose();
   });
 
-  function createApp(options = {}) {
+  function createApp(options: GlimmerAppOptions = {}) {
     let pkg = { name: 'glimmer-app-test' };
 
     let cli = new MockCLI();
@@ -38,13 +38,15 @@ describe('glimmer-app', function() {
   describe('constructor', function() {
     it('throws an error if no arguments are provided', function() {
       expect(() => {
-        new GlimmerApp();
+        const AnyGlimmerApp = GlimmerApp as any;
+        new AnyGlimmerApp();
       }).to.throw(/must pass through the default arguments/)
     });
 
     it('throws an error if project is not passed through', function() {
       expect(() => {
-        new GlimmerApp({});
+        const AnyGlimmerApp = GlimmerApp as any;
+        new AnyGlimmerApp({});
       }).to.throw(/must pass through the default arguments/)
     });
 

--- a/tests/broccoli/glimmer-app-test.ts
+++ b/tests/broccoli/glimmer-app-test.ts
@@ -137,4 +137,70 @@ describe('glimmer-app', function() {
       });
     });
   });
+
+  describe('cssTree', function() {
+    it('returns null when no styles are present', async function () {
+      input.write({
+        'app': {},
+        'src': {
+          'ui': {
+            'index.html': 'src',
+          },
+        },
+        'config': {},
+      });
+
+      let app = createApp() as any;
+      let output = app.cssTree();
+
+      expect(output).to.be.undefined;
+    });
+
+    it('compiles sass', async function () {
+      input.write({
+        'app': {},
+        'src': {
+          'ui': {
+            'styles': {
+              'app.scss': stripIndent`
+                $font-stack: Helvetica, sans-serif;
+                $primary-color: #333;
+
+                body { font: 100% $font-stack; color: $primary-color; }
+              `,
+            },
+          }
+        },
+        'config': {},
+      });
+
+      let app = createApp() as any;
+      let output = await buildOutput(app.cssTree());
+
+      expect(output.read()).to.deep.equal({
+        'app.css': `body {\n  font: 100% Helvetica, sans-serif;\n  color: #333; }\n`,
+      });
+    });
+
+    it('passes through css', async function () {
+      input.write({
+        'app': {},
+        'src': {
+          'ui': {
+            'styles': {
+              'app.css': `body { color: #333; }`
+            },
+          }
+        },
+        'config': {},
+      });
+
+      let app = createApp() as any;
+      let output = await buildOutput(app.cssTree());
+
+      expect(output.read()).to.deep.equal({
+        'app.css': `body { color: #333; }`
+      });
+    });
+  });
 });

--- a/tests/broccoli/glimmer-app-test.ts
+++ b/tests/broccoli/glimmer-app-test.ts
@@ -124,7 +124,7 @@ describe('glimmer-app', function() {
         },
       });
 
-      let app = createApp();
+      let app = createApp() as any;
       let output = await buildOutput(app.htmlTree());
 
       expect(output.read()).to.deep.equal({
@@ -168,6 +168,8 @@ describe('glimmer-app', function() {
   });
 
   describe('cssTree', function() {
+    it('allows passing custom `src` tree');
+
     it('returns null when no styles are present', async function () {
       input.write({
         'app': {},
@@ -231,5 +233,12 @@ describe('glimmer-app', function() {
         'app.css': `body { color: #333; }`
       });
     });
+  });
+
+  describe('toTree', function() {
+    it('transpiles templates');
+    it('transpiles javascript');
+    it('builds a module map');
+    it('includes resolver config');
   });
 });


### PR DESCRIPTION
* Add tests for `cssTree`
* Add tests for `GlimmerApp` constructor
* Add tests for `.env` property
* Refactor `Trees` interface (remove `Tree` suffix for properties)
* Allow (and test) passing in a custom `{ trees: { src } }`
* Reset `npm test` to use mocha's normal reporter (tap reporter was swallowing errors)