### PR TITLE
Allow customization of app.js output path + flesh out toTree tests

### DIFF
--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -29,8 +29,17 @@ import defaultModuleConfiguration from './default-module-configuration';
 
 const stew  = require('broccoli-stew');
 const find = stew.find;
+const debug = stew.debug;
 
 import { TypeScript } from 'broccoli-typescript-compiler/lib/plugin';
+
+function maybeDebug(inputTree: Tree, name: string) {
+  if (!process.env.GLIMMER_BUILD_DEBUG) {
+    return inputTree;
+  }
+
+  return debug(inputTree, { name });
+}
 
 const DEFAULT_TS_OPTIONS = {
   tsconfig: {
@@ -300,7 +309,7 @@ export default class GlimmerApp {
   }
 
   private rollupTree(jsTree) {
-    return new RollupWithDependencies(jsTree, {
+    return new RollupWithDependencies(maybeDebug(jsTree, 'rollup-input-tree'), {
       inputFiles: ['**/*.js'],
       rollup: {
         format: 'umd',

--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -80,6 +80,7 @@ export interface Project {
 
 export interface TreesOption {
   src?: Tree | string;
+  nodeModules: Tree | string;
 }
 
 export interface Trees {
@@ -160,14 +161,18 @@ export default class GlimmerApp {
       });
     }
 
-    const nodeModulesTree = new Funnel(new UnwatchedDir(this.project.root), {
-      srcDir: 'node_modules/@glimmer',
-      destDir: 'node_modules/@glimmer',
-      include: [
-        '**/*.d.ts',
-        '**/package.json'
-      ]
-    });
+    let nodeModulesTree = trees && trees.nodeModules || new UnwatchedDir(this.resolveLocal('node_modules'));
+
+    if (nodeModulesTree) {
+      nodeModulesTree = new Funnel(nodeModulesTree, {
+        srcDir: '@glimmer',
+        destDir: 'node_modules/@glimmer',
+        include: [
+          '**/*.d.ts',
+          '**/package.json'
+        ]
+      });
+    }
 
     return {
       src: srcTree,
@@ -175,7 +180,12 @@ export default class GlimmerApp {
     }
   }
 
-  private resolveLocal(to) {
+  private resolveLocal(to: string) {
+    // return argument if it is absolute
+    if (to[0] === '/') {
+      return to;
+    }
+
     return path.join(this.project.root, to);
   }
 
@@ -201,7 +211,7 @@ export default class GlimmerApp {
    *
    * @param options
    */
-  public toTree(options) {
+  public toTree() {
     let isProduction = process.env.EMBER_ENV === 'production';
 
     let jsTree = this.javascriptTree();

--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -59,16 +59,21 @@ const DEFAULT_TS_OPTIONS = {
 
 export interface OutputPaths {
   app: {
-    html: string
+    html: string,
+    js: string
   }
 }
-
 export interface EmberCLIDefaults {
   project: Project
 }
 
 export interface Options {
-  outputPaths?: any;
+  outputPaths?: {
+    app?: {
+      html?: string;
+      js?: string
+    }
+  };
   trees?: TreesOption
 }
 
@@ -108,7 +113,7 @@ export interface Tree {
  * @class GlimmerApp
  * @constructor
  * @param {Object} [defaults]
- * @param {Object} [options={}] Configuration options
+ * @param {Object} [options=Options] Configuration options
  */
 export default class GlimmerApp {
   public project: Project;
@@ -149,7 +154,8 @@ export default class GlimmerApp {
   private buildOutputPaths(options: Options): OutputPaths {
     return defaultsDeep({}, options.outputPaths, {
       app: {
-        html: 'index.html'
+        html: 'index.html',
+        js: 'app.js'
       }
     });
   }
@@ -314,7 +320,7 @@ export default class GlimmerApp {
       rollup: {
         format: 'umd',
         entry: 'index.js',
-        dest: 'app.js',
+        dest: this.outputPaths.app.js,
         sourceMap: 'inline'
       }
     });

--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -469,11 +469,13 @@ export default class GlimmerApp {
       project: this.project
     });
 
-    this._cachedConfigTree = new Funnel(configTree, {
+    let namespacedConfigTree = new Funnel(configTree, {
       srcDir: '/',
       destDir: this.name + '/config',
       annotation: 'Funnel (config)'
     });
+
+    this._cachedConfigTree = maybeDebug(namespacedConfigTree, 'config-tree');
 
     return this._cachedConfigTree;
   }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "postpublish": "git push origin master --tags",
     "pretest": "ember build",
     "test": "mocha dist/tests --recursive",
+    "test:debug": "ember build && mocha debug dist/tests --recursive",
     "start": "ember test --server"
   },
   "repository": "https://github.com/glimmerjs/glimmer-application-pipeline",

--- a/tests/broccoli/glimmer-app-test.ts
+++ b/tests/broccoli/glimmer-app-test.ts
@@ -363,5 +363,33 @@ describe('glimmer-app', function() {
       expect(actual['app.js']).to.include('glimmer-app-test');
       expect(actual['app.js']).to.include('definitiveCollection');
     });
+
+    it('honors outputPaths.app.js', async function() {
+      input.write({
+        'src': {
+          'index.ts': '',
+          'ui': {
+            'index.html': 'src'
+          }
+        },
+        'config': {},
+        'tsconfig.json': tsconfigContents
+      });
+
+      let app = createApp({
+        trees: {
+          nodeModules: path.join(__dirname, '..', '..', '..', 'node_modules')
+        },
+        outputPaths: {
+          app: {
+            js: 'foo-bar-file.js'
+          }
+        }
+      });
+      let output = await buildOutput(app.toTree());
+      let actual = output.read();
+
+      expect(actual['foo-bar-file.js']).to.be.defined;
+    });
   });
 });

--- a/tests/broccoli/glimmer-app-test.ts
+++ b/tests/broccoli/glimmer-app-test.ts
@@ -263,6 +263,8 @@ describe('glimmer-app', function() {
   });
 
   describe('toTree', function() {
+    this.timeout(10000);
+
     const tsconfigContents = stripIndent`
       {
         "compilerOptions": {

--- a/tests/broccoli/glimmer-app-test.ts
+++ b/tests/broccoli/glimmer-app-test.ts
@@ -308,8 +308,33 @@ describe('glimmer-app', function() {
       expect(actual['app.js']).to.include('Hello!');
     });
 
-    it('transpiles javascript');
-    it('builds a module map');
+    it('builds a module map', async function() {
+      input.write({
+        'src': {
+          'index.ts': 'import moduleMap from "./config/module-map"; console.log(moduleMap);',
+          'ui': {
+            'index.html': 'src',
+            'components': {
+              'foo-bar.hbs': `<div>Hello!</div>`
+            },
+          }
+        },
+        'config': {},
+        'tsconfig.json': tsconfigContents
+      });
+
+      let app = createApp({
+        trees: {
+          nodeModules: path.join(__dirname, '..', '..', '..', 'node_modules')
+        }
+      });
+      let output = await buildOutput(app.toTree());
+      let actual = output.read();
+
+      expect(actual['index.html']).to.equal('src');
+      expect(actual['app.js']).to.include('component:/glimmer-app-test/components/foo-bar');
+    });
+
     it('includes resolver config');
   });
 });

--- a/tests/broccoli/glimmer-app-test.ts
+++ b/tests/broccoli/glimmer-app-test.ts
@@ -335,6 +335,31 @@ describe('glimmer-app', function() {
       expect(actual['app.js']).to.include('component:/glimmer-app-test/components/foo-bar');
     });
 
-    it('includes resolver config');
+    it('includes resolver config', async function() {
+      input.write({
+        'src': {
+          'index.ts': 'import resolverConfig from "./config/resolver-configuration"; console.log(resolverConfig);',
+          'ui': {
+            'index.html': 'src'
+          }
+        },
+        'config': {},
+        'tsconfig.json': tsconfigContents
+      });
+
+      let app = createApp({
+        trees: {
+          nodeModules: path.join(__dirname, '..', '..', '..', 'node_modules')
+        }
+      });
+      let output = await buildOutput(app.toTree());
+      let actual = output.read();
+
+      // it would be much better to confirm the full expected resolver config
+      // but rollup actually reformats the code so it doesn't match a simple
+      // JSON.stringify'ied version of the defaultModuleConfiguration
+      expect(actual['app.js']).to.include('glimmer-app-test');
+      expect(actual['app.js']).to.include('definitiveCollection');
+    });
   });
 });


### PR DESCRIPTION
* Allow `outputPaths.app.js` to be specified as an option to `new GlimmerApp`
* Add smoke test for handlebars transpilation
* Add smoke test for module map inclusion
* Add smoke test for resolver config inclusion
* Add nice debug tree helpers (when env flag is enabled)
* Allow `nodeModules` tree to be provided (needed for testing, but also seems good as an extension point for "exotic" setups...)