### PR TITLE
Add failing test showing user cannot provided resolver config...

### DIFF
--- a/tests/broccoli/glimmer-app-test.ts
+++ b/tests/broccoli/glimmer-app-test.ts
@@ -391,5 +391,34 @@ describe('glimmer-app', function() {
 
       expect(actual['foo-bar-file.js']).to.be.defined;
     });
+
+    it('includes custom provided resolver configuration', async function() {
+      input.write({
+        'src': {
+          'index.ts': 'import resolverConfig from "./config/resolver-configuration"; console.log(resolverConfig);',
+          'ui': {
+            'index.html': 'src'
+          },
+
+          'config': {
+            'resolver-map.js': '"custom resolver map"'
+          },
+        },
+
+        'config': {
+          'resolver-map.js': '"custom resolver map"'
+        },
+      });
+
+      let app = createApp({
+        trees: {
+          nodeModules: path.join(__dirname, '..', '..', '..', 'node_modules')
+        }
+      });
+      let output = await buildOutput(app.toTree());
+      let actual = output.read();
+
+      expect(actual['app.js']).to.include('"custom resolver map"');
+    });
   });
 });


### PR DESCRIPTION
We do intend to allow this to be user exposed and configurable, but there is no way currently to do so. Placing a resolver config either `src/config/resolver-map.js` or `config/resolver-map.js` has no effect.

