### PR TITLE
Rename `Options` interface to `GlimmerAppOptions`.

### DIFF
--- a/tests/broccoli/glimmer-app-test.ts
+++ b/tests/broccoli/glimmer-app-test.ts
@@ -11,7 +11,7 @@ const Project = require('ember-cli/lib/models/project');
 const { stripIndent } = require('common-tags');
 
 import GlimmerApp, {
-  Options as GlimmerAppOptions
+  GlimmerAppOptions
 } from '../../lib/broccoli/glimmer-app';
 
 const expect = require('../helpers/chai').expect;


### PR DESCRIPTION
* Removes `TreesOption` interface (just operate on `options` throughout)
* Renames `Options` to `GlimmerAppOptions`