### PR TITLE
Remove filtering around `node_modules`.

### DIFF
--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -180,12 +180,7 @@ export default class GlimmerApp {
 
     if (nodeModulesTree) {
       nodeModulesTree = new Funnel(nodeModulesTree, {
-        srcDir: '@glimmer',
-        destDir: 'node_modules/@glimmer',
-        include: [
-          '**/*.d.ts',
-          '**/package.json'
-        ]
+        destDir: 'node_modules/'
       });
     }
 


### PR DESCRIPTION
Allows using other typescript libraries (by not filtering to only `node_modules/@glimmer`).

Fixes https://github.com/glimmerjs/glimmer-build/issues/41.