### PR TITLE
Setup for base use of colocated styles

### DIFF
--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -5,13 +5,12 @@ const ConfigLoader = require('broccoli-config-loader');
 const ConfigReplace = require('broccoli-config-replace');
 
 const Funnel = require('broccoli-funnel');
-const concat = require('broccoli-concat');
 const path  = require('path');
 const fs = require('fs');
 const typescript = require('broccoli-typescript-compiler').typescript;
 const existsSync = require('exists-sync');
 const merge = require('broccoli-merge-trees');
-const compileSass = require('broccoli-sass');
+const StyleManifest = require('broccoli-style-manifest');
 const assetRev = require('broccoli-asset-rev');
 const uglify = require('broccoli-uglify-sourcemap');
 const ResolutionMapBuilder = require('@glimmer/resolution-map-builder');
@@ -69,6 +68,15 @@ export interface OutputPaths {
     css: string;
   }
 }
+
+export interface StyleConfig {
+  colocation?: boolean;
+  preprocessor?: {
+    type?: any;
+    extensions?: Array<string>;
+    options?: object;
+  }
+}
 export interface EmberCLIDefaults {
   project: Project
 }
@@ -85,6 +93,7 @@ export interface GlimmerAppOptions {
     src?: Tree | string;
     nodeModules?: Tree | string;
   }
+  styleConfig?: StyleConfig;
 }
 
 export interface Addon {
@@ -125,6 +134,7 @@ export default class GlimmerApp {
   public name: string;
   public env: 'production' | 'development' | 'test';
   private outputPaths: OutputPaths;
+  private styleConfig: StyleConfig;
 
   protected trees: Trees;
 
@@ -144,6 +154,7 @@ export default class GlimmerApp {
 
     this.trees = this.buildTrees(options);
     this.outputPaths = this.buildOutputPaths(options);
+    this.styleConfig = this.buildStyleConfig(options);
   }
 
   private _configReplacePatterns() {
@@ -163,6 +174,18 @@ export default class GlimmerApp {
         js: 'app.js',
         css: 'app.css'
       }
+    });
+  }
+
+  private buildStyleConfig(options: GlimmerAppOptions): StyleConfig {
+    return defaultsDeep({
+      preprocessor: {
+        type: require('broccoli-sass'),
+        extensions: ['css', 'scss'],
+        options: {}
+      }
+    }, options.styleConfig, {
+      colocation: false
     });
   }
 
@@ -371,28 +394,43 @@ export default class GlimmerApp {
   }
 
   private cssTree() {
-    // should really make SASS support to be opt-in, so that
-    // we can properly honor the `GlimmerAppOptions.trees.src`
-    // abstraction here, but for now we still require `src` to be a
-    // "real" path on disk that we check
-    let stylesPath = path.join(this.resolveLocal('src'), 'ui', 'styles');
+    const cssName = this.outputPaths.app.css;
+    const {
+      type: preprocessor,
+      options,
+      extensions,
+    } = this.styleConfig.preprocessor;
 
-    if (fs.existsSync(stylesPath)) {
-      // Compile SASS if app.scss is present
-      // (this works with imports from app.scss)
-      let scssPath = path.join(stylesPath, 'app.scss');
-      if (fs.existsSync(scssPath)) {
-        return compileSass([stylesPath], 'app.scss', this.outputPaths.app.css, {
-          annotation: 'Funnel: scss'
-        });
+    let stylesTree = this.trees.src;
+    if (!this.styleConfig.colocation) {
+      stylesTree = path.join(this.resolveLocal('src'), 'ui', 'styles');
+      if (!fs.existsSync(stylesTree)) {
+        return undefined;
       }
-
-      // Otherwise concat all the css in the styles dir
-      return concat(new Funnel(stylesPath, {
-        include: ['**/*.css'],
-        annotation: 'Funnel: css'}),
-        { outputFile: this.outputPaths.app.css });
     }
+
+    const styles = new Funnel(stylesTree, {
+      include: [`**/*.{${extensions.join(',')},}`],
+      // for simplicty sake, convert all css files to scss files
+      // inorder to facilitate importing
+      getDestinationPath(relativePath) {
+        return relativePath.replace(/\.css$/, '.scss');
+      },
+      annotation: 'Funnel: all style files'
+    });
+
+    const styleManifestFileName = '__glimmer_app_manifest';
+    const styleManifest = new StyleManifest(styles, {
+      outputFileNameWithoutExtension: styleManifestFileName,
+      defaultExtension: 'scss',
+      annotation: 'StyleManifest: css'
+    });
+
+    return preprocessor([
+      merge([styles, styleManifest])
+    ], `${styleManifestFileName}.scss`, cssName, defaultsDeep({
+      annotation: 'Funnel: scss'
+    }, options));
   }
 
   private publicTree() {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "broccoli-source": "^1.1.0",
     "broccoli-stew": "^1.3.1",
     "broccoli-string-replace": "^0.1.1",
+    "broccoli-style-manifest": "^1.2.1",
     "broccoli-typescript-compiler": "^1.0.1",
     "broccoli-uglify-sourcemap": "^1.4.0",
     "ember-cli-inject-live-reload": "^1.4.1",

--- a/tests/broccoli/glimmer-app-test.ts
+++ b/tests/broccoli/glimmer-app-test.ts
@@ -240,6 +240,38 @@ describe('glimmer-app', function() {
       });
     });
 
+    it('handles colocated styles', async function () {
+      input.write({
+        'app': {},
+        'src': {
+          'ui': {
+            'components': {
+              'test-component': {
+                'style.scss': stripIndent`
+                  $font-stack: Helvetica, sans-serif;
+                  $primary-color: #333;
+
+                  body { font: 100% $font-stack; color: $primary-color; }
+                `,
+              }
+            },
+          }
+        },
+        'config': {},
+      });
+
+      let app = createApp({
+        styleConfig: {
+          colocation: true
+        }
+      }) as any;
+      let output = await buildOutput(app.cssTree());
+
+      expect(output.read()).to.deep.equal({
+        'app.css': `body {\n  font: 100% Helvetica, sans-serif;\n  color: #333; }\n`,
+      });
+    });
+
     it('passes through css', async function () {
       input.write({
         'app': {},
@@ -257,7 +289,7 @@ describe('glimmer-app', function() {
       let output = await buildOutput(app.cssTree());
 
       expect(output.read()).to.deep.equal({
-        'app.css': `body { color: #333; }`
+        'app.css': `body {\n  color: #333; }\n`
       });
     });
 
@@ -284,7 +316,7 @@ describe('glimmer-app', function() {
       let output = await buildOutput(app.cssTree());
 
       expect(output.read()).to.deep.equal({
-        'foo-bar.css': `body { color: #333; }`
+        'foo-bar.css': `body {\n  color: #333; }\n`
       });
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1305,6 +1305,15 @@ broccoli-string-replace@^0.1.1:
     broccoli-persistent-filter "^1.1.5"
     minimatch "^3.0.3"
 
+broccoli-style-manifest@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/broccoli-style-manifest/-/broccoli-style-manifest-1.2.1.tgz#5c22b39264aa50a24cf66be1c7fb446a99e87dcd"
+  dependencies:
+    broccoli-plugin "^1.3.0"
+    fs-tree-diff "^0.5.6"
+    rsvp "^3.5.0"
+    walk-sync "^0.3.1"
+
 broccoli-test-helper@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/broccoli-test-helper/-/broccoli-test-helper-1.1.0.tgz#7ec8a5efc33e2299b6592ca066f6f58645480bda"
@@ -4653,7 +4662,7 @@ rollup@^0.41.4, rollup@^0.41.6:
   dependencies:
     source-map-support "^0.4.0"
 
-rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.6, rsvp@^3.2.1, rsvp@^3.3.3:
+rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.6, rsvp@^3.2.1, rsvp@^3.3.3, rsvp@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.5.0.tgz#a62c573a4ae4e1dfd0697ebc6242e79c681eaa34"
 


### PR DESCRIPTION
I know that in the comments of #35 it is stated 

> We’re not taking a stance on colocation (yet).

and that this is due to a

> need to define the semantics ;)

because of the debate on whether or not 

> by default we want to somehow scope those styles to the component with which they're co-located.

Having clearly stated that, I wanted to propose this to get the ball rolling on colocated styles. It appears, even from the comments in #35 that colocation is desired and even agreed upon, but the idea of scoping, namespacing, modules, themeing, etc, has not been decided upon yet.

Durring ember conf, we had a productive meeting between @ebryn, @dfreeman and others about the css story of Ember and glimmer. The main thing that we all agreed upon, and saw as a base for opening up all the other doors of the css story, was colocation. So, in keeping with the "exposing better primitives to facilitate experimentation" we wanted to get the ball rolling on the base of colocation.

In order to use the colocation, I did however put an opt in flag of 
```javascript
  let app = new GlimmerApp(defaults, {
    styleConfig: {
      colocation: true
    }
  });
```
I assume that we wish to have this be more of a "unification" and not have opt in/outs, but due to the delicacy of colocated styles, wanted it to be more opt in for the time being. I could remove the flag and have both work simultaneously if we wanted, however with module unification, a style directory would no longer be needed.