### PR TITLE
Fixup warnings RE: *.hbs -> *.js types.

### DIFF
--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -352,10 +352,6 @@ export default class GlimmerApp {
   }
 
   private buildResolutionMap(src) {
-    src = find(src, {
-      exclude: ['config/**/*']
-    });
-
     return new ResolutionMapBuilder(src, this._configTree(), {
       configPath: this._configPath(),
       defaultModulePrefix: this.name,

--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -264,13 +264,17 @@ export default class GlimmerApp {
   private javascriptTree() {
     let { src, nodeModules } = this.trees;
 
+    let srcWithoutHBSTree = new Funnel(src, {
+      exclude: ['**/*.hbs', '**/*.ts']
+    });
+
     // Compile the TypeScript and Handlebars files into JavaScript
     const compiledHandlebarsTree = this.compiledHandlebarsTree(src);
     const compiledTypeScriptTree = this.compiledTypeScriptTree(compiledHandlebarsTree, nodeModules)
 
     // the output tree from typescript only includes the output from .ts -> .js transpilation
     // and no other files from the original source tree
-    const combinedHandlebarsAndTypescriptTree = merge([compiledHandlebarsTree, compiledTypeScriptTree], { overwrite: true});
+    const combinedHandlebarsAndTypescriptTree = merge([srcWithoutHBSTree, compiledTypeScriptTree], { overwrite: true});
 
     // Remove top-most `src` directory so module names don't include it.
     const resolvableTree = new Funnel(combinedHandlebarsAndTypescriptTree, {

--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -27,9 +27,6 @@ import defaultModuleConfiguration from './default-module-configuration';
 //const Logger = require('heimdalljs-logger');
 //const logger = Logger('@glimmer/application-pipeline:glimmer-app');
 
-const stew  = require('broccoli-stew');
-const find = stew.find;
-const debug = stew.debug;
 
 import { TypeScript } from 'broccoli-typescript-compiler/lib/plugin';
 
@@ -37,6 +34,8 @@ function maybeDebug(inputTree: Tree, name: string) {
   if (!process.env.GLIMMER_BUILD_DEBUG) {
     return inputTree;
   }
+
+  const debug = require('broccoli-stew').debug;
 
   // preserve `null` trees
   if (!inputTree) {

--- a/lib/broccoli/glimmer-template-precompiler.ts
+++ b/lib/broccoli/glimmer-template-precompiler.ts
@@ -1,14 +1,9 @@
 const Filter = require('broccoli-persistent-filter');
-const precompile = require('@glimmer/compiler').precompile;
-
-interface TemplateMeta {
-  '<template-meta>': true;
-  specifier: string;
-}
+import { precompile } from '@glimmer/compiler';
 
 class GlimmerTemplatePrecompiler extends Filter {
   extensions = ['hbs'];
-  targetExtension = 'js';
+  targetExtension = 'ts';
   options: any;
 
   constructor(inputNode, options) {
@@ -18,13 +13,13 @@ class GlimmerTemplatePrecompiler extends Filter {
 
   processString(content, relativePath) {
     let specifier = getTemplateSpecifier(this.options.rootName, relativePath);
-    return 'export default ' + precompile<TemplateMeta>(content, { meta: { specifier, '<template-meta>': true } }) + ';';
+    return 'export default ' + precompile(content, { meta: { specifier, '<template-meta>': true } }) + ';';
   }
 }
 
 function getTemplateSpecifier(rootName, relativePath) {
   let path = relativePath.split('/');
-  let prefix = path.shift();
+  path.shift();
 
   // TODO - should use module map config to be rigorous
   if (path[path.length - 1] === 'template.hbs') {

--- a/tests/broccoli/glimmer-app-test.ts
+++ b/tests/broccoli/glimmer-app-test.ts
@@ -1,9 +1,8 @@
 'use strict';
 
 const path = require('path');
-const broccoliTestHelper = require('broccoli-test-helper');
-const buildOutput = broccoliTestHelper.buildOutput;
-const createTempDir = broccoliTestHelper.createTempDir;
+
+import { buildOutput, createTempDir, TempDir } from 'broccoli-test-helper';
 
 const MockCLI = require('ember-cli/tests/helpers/mock-cli');
 const Project = require('ember-cli/lib/models/project');
@@ -17,7 +16,7 @@ import GlimmerApp, {
 const expect = require('../helpers/chai').expect;
 
 describe('glimmer-app', function() {
-  let input;
+  let input: TempDir;
 
   beforeEach(function() {
     return createTempDir().then(tempDir => (input = tempDir));


### PR DESCRIPTION
* Change template precompiler to emit *.ts files.
* Use typing info from @glimmer/compiler (instead of inlining the interfaces)
* Remove extraneous filtering of input trees