### PR TITLE
Do not nest config inside `src`.

### DIFF
--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -266,39 +266,26 @@ export default class GlimmerApp {
   private javascriptTree() {
     let { src, nodeModules } = this.trees;
 
+    const configTree = this.buildConfigTree(src);
+
     let srcWithoutHBSTree = new Funnel(src, {
       exclude: ['**/*.hbs', '**/*.ts']
     });
 
     // Compile the TypeScript and Handlebars files into JavaScript
     const compiledHandlebarsTree = this.compiledHandlebarsTree(src);
-    const compiledTypeScriptTree = this.compiledTypeScriptTree(compiledHandlebarsTree, nodeModules)
+    const combinedConfigAndCompiledHandlebarsTree = merge([configTree, compiledHandlebarsTree]);
+    const compiledTypeScriptTree = this.compiledTypeScriptTree(combinedConfigAndCompiledHandlebarsTree, nodeModules)
 
     // the output tree from typescript only includes the output from .ts -> .js transpilation
     // and no other files from the original source tree
     const combinedHandlebarsAndTypescriptTree = merge([srcWithoutHBSTree, compiledTypeScriptTree], { overwrite: true});
 
-    // Remove top-most `src` directory so module names don't include it.
-    const resolvableTree = new Funnel(combinedHandlebarsAndTypescriptTree, {
-      srcDir: 'src'
-    });
-
-    // Build the file that maps individual modules onto the resolver's specifier
-    // keys.
-    const moduleMap = this.buildResolutionMap(resolvableTree);
-
-    // Build the resolver configuration file.
-    const resolverConfiguration = this.buildResolverConfiguration();
-
     // Merge the JavaScript source and generated module map and resolver
     // configuration files together, making sure to overwrite the stub
     // module-map.js and resolver-configuration.js in the source tree with the
     // generated ones.
-    let jsTree = merge([
-      resolvableTree,
-      moduleMap,
-      resolverConfiguration
-    ], { overwrite: true });
+    let jsTree = merge([combinedHandlebarsAndTypescriptTree, configTree], { overwrite: true });
 
     // Finally, bundle the app into a single rolled up .js file.
     return this.rollupTree(jsTree);
@@ -327,7 +314,7 @@ export default class GlimmerApp {
       inputFiles: ['**/*.js'],
       rollup: {
         format: 'umd',
-        entry: 'index.js',
+        entry: 'src/index.js',
         dest: this.outputPaths.app.js,
         sourceMap: 'inline'
       }
@@ -345,16 +332,22 @@ export default class GlimmerApp {
     });
   }
 
-  private rewriteConfigEnvironment(src) {
-    return new ConfigReplace(src, this._configTree(), {
-      configPath: this._configPath(),
-      files: [ 'config/environment.js' ],
-      patterns: this._configReplacePatterns()
-    });
+  private buildConfigTree(postTranspiledSrc) {
+    // Build the file that maps individual modules onto the resolver's specifier
+    // keys.
+    const moduleMap = this.buildResolutionMap(postTranspiledSrc);
+
+    // Build the resolver configuration file.
+    const resolverConfiguration = this.buildResolverConfiguration();
+
+    const configTree = this._configTree();
+
+    return merge([moduleMap, resolverConfiguration, configTree]);
   }
 
   private buildResolutionMap(src) {
     return new ResolutionMapBuilder(src, this._configTree(), {
+      baseDir: 'src',
       configPath: this._configPath(),
       defaultModulePrefix: this.name,
       defaultModuleConfiguration
@@ -463,7 +456,7 @@ export default class GlimmerApp {
   }
 
   protected _configPath(): string {
-    return path.join(this.name, 'config', 'environments', this.env + '.json');
+    return path.join('config', 'environments', this.env + '.json');
   }
 
   _cachedConfigTree: any;
@@ -481,7 +474,7 @@ export default class GlimmerApp {
 
     let namespacedConfigTree = new Funnel(configTree, {
       srcDir: '/',
-      destDir: this.name + '/config',
+      destDir: 'config',
       annotation: 'Funnel (config)'
     });
 

--- a/lib/broccoli/glimmer-template-precompiler.ts
+++ b/lib/broccoli/glimmer-template-precompiler.ts
@@ -1,23 +1,30 @@
+const path = require('path');
 const Filter = require('broccoli-persistent-filter');
 import { precompile } from '@glimmer/compiler';
+import { PrecompileOptions, TemplateMeta } from '@glimmer/wire-format';
 
 class GlimmerTemplatePrecompiler extends Filter {
   extensions = ['hbs'];
   targetExtension = 'ts';
-  options: any;
+  rootName: string;
 
   constructor(inputNode, options) {
-    super(...arguments)
-    this.options = options || {};
+    super(inputNode, { persist: false }); // TODO: enable persistent output
+
+    this.rootName = options.rootName;
   }
 
   processString(content, relativePath) {
-    let specifier = getTemplateSpecifier(this.options.rootName, relativePath);
-    return 'export default ' + precompile(content, { meta: { specifier, '<template-meta>': true } }) + ';';
+    let specifier = getTemplateSpecifier(this.rootName, relativePath);
+    return 'export default ' + this.precompile(content, { meta: { specifier, '<template-meta>': true } }) + ';';
+  }
+
+  precompile(content: string, options: PrecompileOptions<TemplateMeta>): string {
+    return precompile(content, options);
   }
 }
 
-function getTemplateSpecifier(rootName, relativePath) {
+export function getTemplateSpecifier(rootName, relativePath) {
   let path = relativePath.split('/');
   path.shift();
 

--- a/lib/broccoli/glimmer-template-precompiler.ts
+++ b/lib/broccoli/glimmer-template-precompiler.ts
@@ -25,18 +25,25 @@ class GlimmerTemplatePrecompiler extends Filter {
 }
 
 export function getTemplateSpecifier(rootName, relativePath) {
-  let path = relativePath.split('/');
-  path.shift();
+  let pathParts = relativePath.split('/');
+  pathParts.shift();
 
   // TODO - should use module map config to be rigorous
-  if (path[path.length - 1] === 'template.hbs') {
-    path.pop();
-  }
-  if (path[0] === 'ui') {
-    path.shift();
+  if (pathParts[pathParts.length - 1] === 'template.hbs') {
+    pathParts.pop();
   }
 
-  return 'template:/' + rootName + '/' + path.join('/');
+  if (path.extname(pathParts[pathParts.length - 1]) === '.hbs') {
+    let fileName = pathParts.pop();
+
+    pathParts.push(path.basename(fileName, '.hbs'));
+  }
+
+  if (pathParts[0] === 'ui') {
+    pathParts.shift();
+  }
+
+  return 'template:/' + rootName + '/' + pathParts.join('/');
 }
 
 export default GlimmerTemplatePrecompiler;

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   "dependencies": {
     "@glimmer/compiler": "^0.23.0-alpha.11",
     "@glimmer/di": "^0.2.0",
-    "@glimmer/resolution-map-builder": "^0.3.3",
-    "@glimmer/resolver-configuration-builder": "^0.1.1",
+    "@glimmer/resolution-map-builder": "^0.3.4",
+    "@glimmer/resolver-configuration-builder": "^0.1.2",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-preset-es2015": "^6.22.0",
     "broccoli-asset-rev": "^2.4.3",
@@ -62,6 +62,7 @@
   },
   "devDependencies": {
     "@glimmer/build": "^0.6.1",
+    "@glimmer/resolver": "^0.3.0",
     "@types/mocha": "^2.2.40",
     "@types/node": "^7.0.12",
     "broccoli-test-helper": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "rollup": "^0.41.6",
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-node-resolve": "^2.0.0",
+    "silent-error": "^1.0.1",
     "walk-sync": "^0.3.1"
   },
   "devDependencies": {

--- a/tests/broccoli/glimmer-app-test.ts
+++ b/tests/broccoli/glimmer-app-test.ts
@@ -87,6 +87,22 @@ describe('glimmer-app', function() {
         expect(app.env).to.equal('test');
       })
     })
+
+    describe('invalid blueprint detection', function() {
+      it('provides nice error when project contains older blueprint contents', function() {
+        input.write({
+          'src': {
+            'main.ts': "import moduleMap from './config/module-map';",
+            'ui': {
+              'index.html': 'src',
+            },
+          },
+          'config': {},
+        });
+
+        expect(() => createApp()).to.throw(/Updates to your project structure are required to run with this version of @glimmer\/application-pipeline./);
+      });
+    });
   });
 
   describe('htmlTree', function() {

--- a/tests/broccoli/glimmer-app-test.ts
+++ b/tests/broccoli/glimmer-app-test.ts
@@ -60,7 +60,11 @@ describe('glimmer-app', function() {
       });
 
       afterEach(function() {
-        process.env.EMBER_ENV = ORIGINAL_EMBER_ENV;
+        if (ORIGINAL_EMBER_ENV) {
+          process.env.EMBER_ENV = ORIGINAL_EMBER_ENV;
+        } else {
+          delete process.env.EMBER_ENV;
+        }
       });
 
       it('sets an `env`', function() {
@@ -371,7 +375,7 @@ describe('glimmer-app', function() {
     it('builds a module map', async function() {
       input.write({
         'src': {
-          'index.ts': 'import moduleMap from "./config/module-map"; console.log(moduleMap);',
+          'index.ts': 'import moduleMap from "../config/module-map"; console.log(moduleMap);',
           'ui': {
             'index.html': 'src',
             'components': {
@@ -392,13 +396,13 @@ describe('glimmer-app', function() {
       let actual = output.read();
 
       expect(actual['index.html']).to.equal('src');
-      expect(actual['app.js']).to.include('component:/glimmer-app-test/components/foo-bar');
+      expect(actual['app.js']).to.include('template:/glimmer-app-test/components/foo-bar');
     });
 
     it('includes resolver config', async function() {
       input.write({
         'src': {
-          'index.ts': 'import resolverConfig from "./config/resolver-configuration"; console.log(resolverConfig);',
+          'index.ts': 'import resolverConfig from "../config/resolver-configuration"; console.log(resolverConfig);',
           'ui': {
             'index.html': 'src'
           }

--- a/tests/broccoli/glimmer-template-precompiler-test.ts
+++ b/tests/broccoli/glimmer-template-precompiler-test.ts
@@ -1,0 +1,67 @@
+'use strict';
+
+import { buildOutput, createTempDir, TempDir } from 'broccoli-test-helper';
+
+import GlimmerTemplatePrecompiler, {
+  getTemplateSpecifier
+} from '../../lib/broccoli/glimmer-template-precompiler';
+
+const expect = require('../helpers/chai').expect;
+
+describe('glimmer-template-precompiler', function() {
+  let input: TempDir;
+
+  beforeEach(function() {
+    return createTempDir().then(tempDir => (input = tempDir));
+  });
+
+  afterEach(function() {
+    return input.dispose();
+  });
+
+  describe('basic broccoli functionality', function() {
+    class MockTemplatePrecompiler extends GlimmerTemplatePrecompiler {
+      precompile(content) {
+        return content.toUpperCase();
+      }
+    }
+
+    it('emits the precompiler as a default export', async function() {
+      input.write({
+        'ui': {
+          'components': {
+            'foo-bar.hbs': '"some template here"'
+          }
+        }
+      });
+
+      let templateCompiler = new MockTemplatePrecompiler(input.path(), { rootName: 'foo-bar-app' });
+      let output = await buildOutput(templateCompiler);
+
+      expect(output.read()).to.deep.equal({
+        'ui': {
+          'components': {
+            'foo-bar.ts': 'export default "SOME TEMPLATE HERE";'
+          }
+        }
+      });
+    });
+  });
+
+  describe('getTemplateSpecifier', function() {
+    const rootName = 'some-root-name';
+
+    const cases = [
+      ['ui/components/foo-bar/template.hbs', 'template:/some-root-name/components/foo-bar']
+    ];
+
+    cases.forEach(function(parts) {
+      let input = parts[0];
+      let expected = parts[1];
+
+      it(input, function() {
+        expect(getTemplateSpecifier(rootName, input)).to.equal(expected);
+      })
+    });
+  });
+});

--- a/tests/broccoli/glimmer-template-precompiler-test.ts
+++ b/tests/broccoli/glimmer-template-precompiler-test.ts
@@ -52,7 +52,8 @@ describe('glimmer-template-precompiler', function() {
     const rootName = 'some-root-name';
 
     const cases = [
-      ['ui/components/foo-bar/template.hbs', 'template:/some-root-name/components/foo-bar']
+      ['ui/components/foo-bar/template.hbs', 'template:/some-root-name/components/foo-bar'],
+      ['ui/components/foo-bar.hbs', 'template:/some-root-name/components/foo-bar'],
     ];
 
     cases.forEach(function(parts) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -64,18 +64,24 @@
   dependencies:
     "@glimmer/wire-format" "^0.23.0-alpha.11"
 
-"@glimmer/resolution-map-builder@^0.3.3":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/resolution-map-builder/-/resolution-map-builder-0.3.3.tgz#8f047e0f032ce5896472fa670f964d60b5e3e4f5"
+"@glimmer/resolution-map-builder@^0.3.4":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/resolution-map-builder/-/resolution-map-builder-0.3.4.tgz#358b7e7e34d035121a62fe5601e39cb2ba37843b"
   dependencies:
     broccoli-plugin "^1.3.0"
     walk-sync "^0.3.1"
 
-"@glimmer/resolver-configuration-builder@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/resolver-configuration-builder/-/resolver-configuration-builder-0.1.1.tgz#ec22f322b862989b60c4e28d8b1fdbbde4883d62"
+"@glimmer/resolver-configuration-builder@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@glimmer/resolver-configuration-builder/-/resolver-configuration-builder-0.1.2.tgz#27f1f73b56386b74b9a1af1f10f89e0b27a69c01"
   dependencies:
     broccoli-plugin "^1.3.0"
+
+"@glimmer/resolver@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/resolver/-/resolver-0.3.0.tgz#65451a2195259ce26518715631c38dd7c144e821"
+  dependencies:
+    "@glimmer/di" "^0.2.0"
 
 "@glimmer/syntax@^0.23.0-alpha.11":
   version "0.23.0-alpha.11"


### PR DESCRIPTION
Addresses https://github.com/glimmerjs/glimmer-application-pipeline/issues/72.

---

**_NOTE:_** This is a breaking change for the current version of the `@glimmer/blueprint`.  I still think this is something we should do, but I'm just pointing out that it will require a SemVer bump to 0.6.0.

To get an idea of the changes needed to a glimmer app, see this [branch of todomvc-demo](https://github.com/glimmerjs/todomvc-demo/compare/master...rwjblue:update-to-latest-application-pipeline).