### PR TITLE
Expose rollup options.

### DIFF
--- a/lib/broccoli/rollup-with-dependencies.ts
+++ b/lib/broccoli/rollup-with-dependencies.ts
@@ -28,7 +28,7 @@ class RollupWithDependencies extends Rollup {
 
     plugins.push(nodeResolve({
       jsnext: true,
-      main: true
+      module: true
     }));
 
     this.rollupOptions.plugins = plugins;

--- a/lib/broccoli/rollup-with-dependencies.ts
+++ b/lib/broccoli/rollup-with-dependencies.ts
@@ -3,6 +3,10 @@ const nodeResolve = require('rollup-plugin-node-resolve');
 const babel = require('rollup-plugin-babel');
 const fs = require('fs');
 
+function hasPlugin(plugins, name) {
+  return plugins.some(plugin => plugin.name === name);
+}
+
 class RollupWithDependencies extends Rollup {
   rollupOptions: any;
   inputPaths: any[];
@@ -12,24 +16,28 @@ class RollupWithDependencies extends Rollup {
 
     plugins.push(loadWithInlineMap());
 
-    plugins.push(babel({
-      presets: [
-        [
-          'es2015',
-          { modules: false }
-        ]
-      ],
-      plugins: [
-        'external-helpers'
-      ],
-      sourceMaps: 'inline',
-      retainLines: false
-    }));
+    if (!hasPlugin(plugins, 'babel')) {
+      plugins.push(babel({
+        presets: [
+          [
+            'es2015',
+            { modules: false }
+          ]
+        ],
+        plugins: [
+          'external-helpers'
+        ],
+        sourceMaps: 'inline',
+        retainLines: false
+      }));
+    }
 
-    plugins.push(nodeResolve({
-      jsnext: true,
-      module: true
-    }));
+    if (!hasPlugin(plugins, 'resolve')) {
+      plugins.push(nodeResolve({
+        jsnext: true,
+        module: true
+      }));
+    }
 
     this.rollupOptions.plugins = plugins;
 

--- a/tests/broccoli/glimmer-app-test.ts
+++ b/tests/broccoli/glimmer-app-test.ts
@@ -469,5 +469,39 @@ describe('glimmer-app', function() {
 
       expect(actual['foo-bar-file.js']).to.be.defined;
     });
+
+    it('allows specifying rollup options', async function() {
+      input.write({
+        'src': {
+          'index.ts': 'console.log("NOW YOU SEE ME");',
+          'ui': {
+            'index.html': 'src'
+          }
+        },
+        'config': {},
+        'tsconfig.json': tsconfigContents
+      });
+
+      let app = createApp({
+        trees: {
+          nodeModules: path.join(__dirname, '..', '..', '..', 'node_modules')
+        },
+        rollup: {
+          plugins: [
+            {
+              name: 'test-replacement',
+              transform(code, id) {
+                return code.replace('NOW YOU SEE ME', 'NOW YOU DON\'T');
+              }
+            }
+          ]
+        }
+      });
+
+      let output = await buildOutput(app.toTree());
+      let actual = output.read();
+
+      expect(actual['app.js']).to.include('NOW YOU DON\'T');
+    });
   });
 });


### PR DESCRIPTION
* Changes default `rollup-plugin-node-resolve` settings to:

```js
require('rollup-plugin-node-resolve')({
  jsnext: true,
  module: true
});
```

---

As discussed, this allows consumers to opt-in to using CJS modules (we only want to support standard ES modules out of the box).  An example of this would look like:

```js
// ember-cli-build.js
const GlimmerApp = require('@glimmer/application-pipeline').GlimmerApp;
const resolve = require('rollup-plugin-node-resolve');
const commonjs = require('rollup-plugin-commonjs');

module.exports = function(defaults) {
  let app = new GlimmerApp(defaults, {
    rollup: {
      plugins: [
        resolve({ jsnext: true, module: true, main: true }),
        commonjs()
      ]
    }
  });

  return app.toTree();
};
```