### PR TITLE
Add support for postprocessTree('all', tree) in addons.

### DIFF
--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -116,6 +116,7 @@ export interface GlimmerAppOptions {
 
 export interface Addon {
   contentFor: (type: string, config, content: string[]) => string;
+  preprocessTree: (type: string, tree: Tree) => Tree;
 }
 
 export interface Project {
@@ -124,8 +125,15 @@ export interface Project {
   configPath(): string;
   addons: Addon[];
 
+  findAddonByName(name: string): Addon | null;
+
   pkg: {
     name: string;
+  }
+
+  ui: {
+    writeLine(contents: string);
+    writeWarnLine(contents: string);
   }
 }
 
@@ -260,17 +268,12 @@ export default class GlimmerApp extends AbstractBuild {
    * @param options
    */
   public toTree() {
-    let isProduction = process.env.EMBER_ENV === 'production';
-
     let jsTree = this.javascriptTree();
     let cssTree = this.cssTree();
     let publicTree = this.publicTree();
     let htmlTree = this.htmlTree();
 
-    // Minify the JavaScript in production builds.
-    if (isProduction) {
-      jsTree = this.minifyTree(jsTree);
-    }
+    jsTree = this.maybePerformDeprecatedUglify(jsTree);
 
     let trees = [jsTree, htmlTree];
     if (cssTree) {
@@ -282,16 +285,9 @@ export default class GlimmerApp extends AbstractBuild {
 
     let appTree = merge(trees);
 
-    // Fingerprint assets for cache busting in production.
-    if (isProduction) {
-      let extensions = ['js', 'css'];
-      let replaceExtensions = ['html', 'js', 'css'];
+    appTree = this.maybePerformDeprecatedAssetRev(appTree);
 
-      appTree = assetRev(appTree, {
-        extensions,
-        replaceExtensions
-      });
-    }
+    appTree = addonProcessTree(this.project, 'postprocessTree', 'all', appTree);
 
     return appTree;
   }
@@ -354,17 +350,6 @@ export default class GlimmerApp extends AbstractBuild {
     return new RollupWithDependencies(maybeDebug(jsTree, 'rollup-input-tree'), {
       inputFiles: ['**/*.js'],
       rollup: rollupOptions
-    });
-  }
-
-  private minifyTree(jsTree) {
-    return uglify(jsTree, {
-      compress: {
-        screw_ie8: true,
-      },
-      sourceMapConfig: {
-        enabled: false
-      }
     });
   }
 
@@ -517,6 +502,60 @@ export default class GlimmerApp extends AbstractBuild {
     this._cachedConfigTree = maybeDebug(namespacedConfigTree, 'config-tree');
 
     return this._cachedConfigTree;
+  }
+
+  private maybePerformDeprecatedUglify(appTree) {
+    let isProduction = process.env.EMBER_ENV === 'production';
+
+    // if the project does not have broccoli-asset-rev itself
+    // process it with a warning/deprecation
+    if (isProduction && !this.project.findAddonByName('broccoli-asset-rev')) {
+      this.project.ui.writeWarnLine(stripIndent`
+        This project is relying on minification being performed by @glimmer/application-pipeline. That functionality has now been migrated to be performed by addons in your project.
+
+        Please run the following to resolve this warning:
+
+          ember install ember-cli-uglify
+      `);
+
+      appTree = uglify(appTree, {
+        compress: {
+          screw_ie8: true,
+        },
+        sourceMapConfig: {
+          enabled: false
+        }
+      });
+    }
+
+    return appTree;
+  }
+
+  private maybePerformDeprecatedAssetRev(appTree) {
+    let isProduction = process.env.EMBER_ENV === 'production';
+
+    // if the project does not have broccoli-asset-rev itself
+    // process it with a warning/deprecation
+    if (isProduction && !this.project.findAddonByName('broccoli-asset-rev')) {
+      this.project.ui.writeWarnLine(stripIndent`
+        This project is relying on asset fingerprinting from @glimmer/application-pipeline. That functionality has now been migrated to be performed by addons in your project.
+
+        Please run the following to resolve this warning:
+
+          ember install broccoli-asset-rev
+      `);
+
+      // Fingerprint assets for cache busting in production.
+      let extensions = ['js', 'css'];
+      let replaceExtensions = ['html', 'js', 'css'];
+
+      appTree = assetRev(appTree, {
+        extensions,
+        replaceExtensions
+      });
+    }
+
+    return appTree;
   }
 
   private detectInvalidBlueprint(options) {


### PR DESCRIPTION
Apps that haven't updated to the latest blueprint will see the following message:

```
WARNING: This project is relying on behaviors provided by @glimmer/application-pipeline that will be removed in future versions. The underlying functionality has now been migrated to be performed by addons in your project.

Please run the following to resolve this warning:

  ember install ember-cli-uglify
  ember install broccoli-asset-rev
```

Running the commands listed will resolve the warnings.