### PR TITLE
Fixup issues around migration to addons.

### DIFF
--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -64,21 +64,6 @@ const DEFAULT_TS_OPTIONS = {
   }
 };
 
-const DEFAULT_GLIMMER_APP_OPTIONS = {
-  addons: {
-    blacklist: [],
-    whitelist: []
-  },
-  outputPaths: {
-      app: {
-        html: 'index.html',
-        js: 'app.js',
-        css: 'app.css'
-      }
-  },
-  rollup: {}
-};
-
 export interface OutputPaths {
   app: {
     html: string;
@@ -117,6 +102,7 @@ export interface GlimmerAppOptions {
 export interface Addon {
   contentFor: (type: string, config, content: string[]) => string;
   preprocessTree: (type: string, tree: Tree) => Tree;
+  included: (GlimmerApp) => void;
 }
 
 export interface Project {
@@ -175,7 +161,28 @@ export default class GlimmerApp extends AbstractBuild {
       throw new Error(missingProjectMessage);
     }
 
-    let defaults = Object.assign({}, upstreamDefaults, DEFAULT_GLIMMER_APP_OPTIONS);
+    let isProduction = process.env.EMBER_ENV === 'production';
+
+    let defaults = Object.assign({}, upstreamDefaults, {
+      addons: {
+        whitelist: null as string[] | null,
+        blacklist: null as string[] | null,
+      },
+      outputPaths: {
+        app: {
+          html: 'index.html',
+          js: 'app.js',
+          css: 'app.css'
+        }
+      },
+      rollup: { },
+      minifyJS: {
+        enabled: isProduction,
+      },
+      sourcemaps: {
+        enabled: !isProduction
+      }
+    });
 
     super(defaults, options);
 


### PR DESCRIPTION
Main issues identified:

* If `options.addons.blacklist` and `options.addons.whitelist` are both empty arrays, no addons are included. Turns out, if you do this you can't even serve assets :scream:.
* `options.minifyJS` was not being set, so for prod builds `ember-cli-uglify` would throw an error (trying to access `options.minifyJS.enabled`)
* Ensure `options.sourcemaps.enabled` is false for production builds (some issues exist around rollup generating inline sourcemaps here)

All of these issues are fixed here, via:

* default `options.addons.blacklist` and `options.addons.whitelist` to `null`
* Default `options.minifyJS.enabled` to `true` for production builds
* Default `options.sourcemaps.enabled` to `true` for non-production builds.