### PR TITLE
Honor disabling sourcemaps via ember-cli-build.js config.

### DIFF
--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -361,7 +361,7 @@ Please run the following to resolve this warning:
         format: 'umd',
         entry: 'src/index.js',
         dest: this.outputPaths.app.js,
-        sourceMap: 'inline'
+        sourceMap: this.options.sourcemaps.enabled
     });
 
     return new RollupWithDependencies(maybeDebug(jsTree, 'rollup-input-tree'), {

--- a/lib/broccoli/rollup-with-dependencies.ts
+++ b/lib/broccoli/rollup-with-dependencies.ts
@@ -13,8 +13,11 @@ class RollupWithDependencies extends Rollup {
 
   build(...args) {
     let plugins = this.rollupOptions.plugins || [];
+    let sourceMapsEnabled = !!this.rollupOptions.sourceMap;
 
-    plugins.push(loadWithInlineMap());
+    if (sourceMapsEnabled) {
+      plugins.push(loadWithInlineMap());
+    }
 
     if (!hasPlugin(plugins, 'babel')) {
       plugins.push(babel({
@@ -27,7 +30,7 @@ class RollupWithDependencies extends Rollup {
         plugins: [
           'external-helpers'
         ],
-        sourceMaps: 'inline',
+        sourceMaps: sourceMapsEnabled && 'inline',
         retainLines: false
       }));
     }


### PR DESCRIPTION
Allows apps to disable sourcemap generation via:

```js
module.exports = function(defaults) {
  let app = new GlimmerApp(defaults, {
    sourcemaps: { enabled: false }
  });

  return app.toTree();
};
```

This follows along with the same API used in ember-cli apps.