### PR TITLE
Shave off some duplication in output.

### DIFF
--- a/lib/broccoli/rollup-with-dependencies.ts
+++ b/lib/broccoli/rollup-with-dependencies.ts
@@ -38,7 +38,29 @@ class RollupWithDependencies extends Rollup {
     if (!hasPlugin(plugins, 'resolve')) {
       plugins.push(nodeResolve({
         jsnext: true,
-        module: true
+        module: true,
+        modulesOnly: true,
+
+        // this is a temporary work around to force all @glimmer/*
+        // packages to use the `es2017` output (they are currently
+        // using `es5` output)
+        //
+        // this should be removed once the various glimmerjs/glimmer-vm
+        // packages have been updated to use the "Correct" module entry
+        // point
+        customResolveOptions:{
+          packageFilter(pkg, file) {
+            if (pkg.name.startsWith('@glimmer/')) {
+              pkg.main = 'dist/modules/es2017/index.js';
+            } else if (pkg.module) {
+              pkg.main = pkg.module;
+            } else if (pkg['jsnext:main']) {
+              pkg.main = pkg['jsnext:main'];
+            }
+
+            return pkg;
+          }
+        }
       }));
     }
 

--- a/lib/broccoli/rollup-with-dependencies.ts
+++ b/lib/broccoli/rollup-with-dependencies.ts
@@ -24,7 +24,7 @@ class RollupWithDependencies extends Rollup {
         presets: [
           [
             'es2015',
-            { modules: false }
+            { modules: false, loose: true }
           ]
         ],
         plugins: [


### PR DESCRIPTION
* Put babel in "loose" mode (removes a number of helper invocations, and generally speeds up transpiled output)
* Force all glimmer packages to use their `dist/modules/es2017` output, instead of `dist/modules/es5` output

Results of this change on newly generated `@glimmer/blueprint` app below.

Before:

```
❯ ember b -prod
cleaning up...
Built project successfully. Stored in "dist/".
File sizes:
 - dist/app-1a294d2bf122a6c7c5987eb976e42e67.css: 22 B (42 B gzipped)
 - dist/app-7afb1b8c5465a6210b49b05612655904.js: 153.52 KB (33.6 KB gzipped)
```

After:

```
❯ ember b -prod
cleaning up...
Built project successfully. Stored in "dist/".
File sizes:
 - dist/app-1a294d2bf122a6c7c5987eb976e42e67.css: 22 B (42 B gzipped)
 - dist/app-c6220f75e37b0002ee6f1fe8f0d2c6c7.js: 130.77 KB (31.35 KB gzipped)
```

Fixes https://github.com/glimmerjs/glimmer-application-pipeline/issues/59.