### PR TITLE
Update ember-build-utilities@0.3.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "broccoli-typescript-compiler": "^1.0.1",
     "broccoli-uglify-sourcemap": "^1.4.0",
     "common-tags": "^1.4.0",
-    "ember-build-utilities": "^0.2.0",
+    "ember-build-utilities": "^0.3.0",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-normalize-entity-name": "^1.0.0",
     "ember-cli-preprocess-registry": "^3.1.1",
@@ -64,6 +64,7 @@
   },
   "devDependencies": {
     "@glimmer/build": "^0.8.1",
+    "@glimmer/compiler": "^0.24.0-beta.4",
     "@glimmer/resolver": "^0.3.0",
     "@types/mocha": "^2.2.41",
     "@types/node": "^7.0.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,25 +46,25 @@
     tslint "^3.15.1"
     typescript "^2.1.5"
 
-"@glimmer/compiler@^0.23.0-alpha.11":
-  version "0.23.0-alpha.11"
-  resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.23.0-alpha.11.tgz#2f2ea9a4e20ed7f080f650a04f1d5c0385a97739"
+"@glimmer/compiler@^0.24.0-beta.4":
+  version "0.24.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.24.0-beta.4.tgz#d90a16b745eddb14c66787ed64816c3a7e220796"
   dependencies:
-    "@glimmer/interfaces" "^0.23.0-alpha.11"
-    "@glimmer/syntax" "^0.23.0-alpha.11"
-    "@glimmer/util" "^0.23.0-alpha.11"
-    "@glimmer/wire-format" "^0.23.0-alpha.11"
+    "@glimmer/interfaces" "^0.24.0-beta.4"
+    "@glimmer/syntax" "^0.24.0-beta.4"
+    "@glimmer/util" "^0.24.0-beta.4"
+    "@glimmer/wire-format" "^0.24.0-beta.4"
     simple-html-tokenizer "^0.3.0"
 
 "@glimmer/di@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@glimmer/di/-/di-0.2.0.tgz#73bfd4a6ee4148a80bf092e8a5d29bcac9d4ce7e"
 
-"@glimmer/interfaces@^0.23.0-alpha.11":
-  version "0.23.0-alpha.11"
-  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.23.0-alpha.11.tgz#18454766efb4e545e74eb8efdf2d17eea81f1394"
+"@glimmer/interfaces@^0.24.0-beta.4":
+  version "0.24.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.24.0-beta.4.tgz#c4ee238d22f9d6805328e986326fcaa042843878"
   dependencies:
-    "@glimmer/wire-format" "^0.23.0-alpha.11"
+    "@glimmer/wire-format" "^0.24.0-beta.4"
 
 "@glimmer/resolution-map-builder@^0.3.8":
   version "0.3.8"
@@ -86,24 +86,24 @@
   dependencies:
     "@glimmer/di" "^0.2.0"
 
-"@glimmer/syntax@^0.23.0-alpha.11":
-  version "0.23.0-alpha.11"
-  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.23.0-alpha.11.tgz#63da79bf932b70b3ed71a3836b712b37a6cc088c"
+"@glimmer/syntax@^0.24.0-beta.4":
+  version "0.24.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.24.0-beta.4.tgz#4e61c912f0f45c43175a178390630da637138e35"
   dependencies:
-    "@glimmer/interfaces" "^0.23.0-alpha.11"
-    "@glimmer/util" "^0.23.0-alpha.11"
+    "@glimmer/interfaces" "^0.24.0-beta.4"
+    "@glimmer/util" "^0.24.0-beta.4"
     handlebars "^4.0.6"
     simple-html-tokenizer "^0.3.0"
 
-"@glimmer/util@^0.23.0-alpha.11":
-  version "0.23.0-alpha.11"
-  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.23.0-alpha.11.tgz#8a706838684381297678cf97b6277a1a6d7668c1"
+"@glimmer/util@^0.24.0-beta.4":
+  version "0.24.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.24.0-beta.4.tgz#d49063e432e2fd2af7bdc1422d3b0d849e6ce328"
 
-"@glimmer/wire-format@^0.23.0-alpha.11", "@glimmer/wire-format@^0.23.0-alpha.7":
-  version "0.23.0-alpha.11"
-  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.23.0-alpha.11.tgz#61d7db874f37959dacb615c247424b0f5faf87b0"
+"@glimmer/wire-format@^0.24.0-beta.4":
+  version "0.24.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.24.0-beta.4.tgz#793acc653e2b718b5052f59943604c0317995b75"
   dependencies:
-    "@glimmer/util" "^0.23.0-alpha.11"
+    "@glimmer/util" "^0.24.0-beta.4"
 
 "@types/mocha@^2.2.41":
   version "2.2.41"
@@ -1798,12 +1798,10 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
-ember-build-utilities@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/ember-build-utilities/-/ember-build-utilities-0.2.0.tgz#561e3193fc1fd00c27ce7f2542f6d8d1e283fdd3"
+ember-build-utilities@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/ember-build-utilities/-/ember-build-utilities-0.3.0.tgz#82a4dfdc6d382bfd730a8cfcf41092b56ba70de6"
   dependencies:
-    "@glimmer/compiler" "^0.23.0-alpha.11"
-    "@glimmer/wire-format" "^0.23.0-alpha.7"
     broccoli-babel-transpiler "^6.0.0"
     broccoli-funnel "^1.1.0"
     broccoli-persistent-filter "^1.2.13"


### PR DESCRIPTION
Moves @glimmer/compiler to be a peerDependency.