### PR TITLE
Test env build

### DIFF
--- a/lib/broccoli/default-module-configuration.ts
+++ b/lib/broccoli/default-module-configuration.ts
@@ -2,7 +2,9 @@ export default {
   types: {
     application: { definitiveCollection: 'main' },
     component: { definitiveCollection: 'components' },
+    'component-test': { unresolvable: true },
     helper: { definitiveCollection: 'components' },
+    'helper-test': { unresolvable: true },
     renderer: { definitiveCollection: 'main' },
     template: { definitiveCollection: 'components' }
   },
@@ -12,7 +14,7 @@ export default {
     },
     components: {
       group: 'ui',
-      types: ['component', 'template', 'helper'],
+      types: ['component', 'component-test', 'template', 'helper', 'helper-test'],
       defaultType: 'component',
       privateCollections: ['utils']
     },

--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -378,7 +378,7 @@ Please run the following to resolve this warning:
 
   private buildResolutionMap(src) {
     return new ResolutionMapBuilder(src, this._configTree(), {
-      baseDir: 'src',
+      srcDir: 'src',
       configPath: this._configPath(),
       defaultModulePrefix: this.name,
       defaultModuleConfiguration

--- a/lib/broccoli/rollup-with-dependencies.ts
+++ b/lib/broccoli/rollup-with-dependencies.ts
@@ -1,9 +1,9 @@
 const nodeResolve = require('rollup-plugin-node-resolve');
 const babel = require('rollup-plugin-babel');
+const GlimmerInlinePrecompile = require('babel-plugin-glimmer-inline-precompile');
 const fs = require('fs');
 const BabelPresetEnv = require('babel-preset-env').default;
 import { Project, Tree, TreeEntry, RollupOptions, GlimmerAppOptions } from '../interfaces';
-
 import DebugMacros from 'babel-plugin-debug-macros';
 
 function hasPlugin(plugins, name) {
@@ -52,6 +52,7 @@ class RollupWithDependencies extends Rollup {
 
       let babelPlugins = [
         'external-helpers',
+        [GlimmerInlinePrecompile],
         [DebugMacros, {
           envFlags: {
             source: '@glimmer/env',

--- a/lib/broccoli/test-entrypoint-builder.ts
+++ b/lib/broccoli/test-entrypoint-builder.ts
@@ -1,0 +1,34 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const walkSync = require('walk-sync');
+
+import { Tree, TreeEntry } from '../interfaces';
+
+export const Plugin: {
+  new (inputNode: TreeEntry[], options?): Tree;
+} = require('broccoli-caching-writer');
+
+export default class TestEntrypointBuilder extends Plugin {
+  constructor(testTree, public options = {}) {
+    super([testTree], {
+      annotation: options['annotation']
+    });
+  }
+
+  build() {
+    let testDir = this.inputPaths[0];
+    let testFiles = walkSync(testDir);
+
+    function isTest({ name }) { return name.match(/\-test$/); }
+    function asImportStatement({ dir, name }) {
+      let testDirRelativePath = `./${path.join(dir, name)}`;
+      return `import '${testDirRelativePath}';\n`;
+    }
+
+    let contents = testFiles.map(path.parse).filter(isTest).map(asImportStatement).join('');
+
+    fs.writeFileSync(path.posix.join(this.outputPath, 'tests.js'), contents, { encoding: 'utf8' });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ember-addon"
   ],
   "dependencies": {
-    "@glimmer/resolution-map-builder": "^0.3.8",
+    "@glimmer/resolution-map-builder": "^0.5.1",
     "@glimmer/resolver-configuration-builder": "^0.1.2",
     "babel-plugin-debug-macros": "^0.1.7",
     "babel-plugin-external-helpers": "^6.22.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@glimmer/resolver-configuration-builder": "^0.1.2",
     "babel-plugin-debug-macros": "^0.1.7",
     "babel-plugin-external-helpers": "^6.22.0",
+    "babel-plugin-glimmer-inline-precompile": "^1.1.0",
     "babel-preset-env": "^1.5.1",
     "broccoli-asset-rev": "^2.4.3",
     "broccoli-babel-transpiler": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@glimmer/resolver-configuration-builder": "^0.1.2",
     "babel-plugin-debug-macros": "^0.1.7",
     "babel-plugin-external-helpers": "^6.22.0",
-    "babel-plugin-glimmer-inline-precompile": "^1.1.0",
     "babel-preset-env": "^1.5.1",
     "broccoli-asset-rev": "^2.4.3",
     "broccoli-babel-transpiler": "^6.0.0",
@@ -68,6 +67,7 @@
   "devDependencies": {
     "@glimmer/build": "^0.8.1",
     "@glimmer/compiler": "^0.26.2",
+    "@glimmer/inline-precompile": "^1.0.1",
     "@glimmer/resolver": "^0.3.0",
     "@types/mocha": "^2.2.41",
     "@types/node": "^7.0.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,6 +60,12 @@
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@glimmer/di/-/di-0.2.0.tgz#73bfd4a6ee4148a80bf092e8a5d29bcac9d4ce7e"
 
+"@glimmer/inline-precompile@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/@glimmer/inline-precompile/-/inline-precompile-1.0.1.tgz#4201119a358002d4bb2b5d8fa633327239fb9336"
+  dependencies:
+    babel-plugin-glimmer-inline-precompile "^1.2.0"
+
 "@glimmer/interfaces@^0.26.2":
   version "0.26.2"
   resolved "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.26.2.tgz#f03e7309584006de164b82ff924692b210888e19"
@@ -490,9 +496,9 @@ babel-plugin-filter-imports@~0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-filter-imports/-/babel-plugin-filter-imports-0.3.1.tgz#e7859b56886b175dd2616425d277b219e209ea8b"
 
-babel-plugin-glimmer-inline-precompile@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/babel-plugin-glimmer-inline-precompile/-/babel-plugin-glimmer-inline-precompile-1.1.0.tgz#31a2506c7085ec138754098a16e702acd4cefe67"
+babel-plugin-glimmer-inline-precompile@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/babel-plugin-glimmer-inline-precompile/-/babel-plugin-glimmer-inline-precompile-1.2.0.tgz#02794b17aac6351da09596b54d9ec675428bba3e"
 
 babel-plugin-strip-glimmer-utils@^0.1.1:
   version "0.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -490,6 +490,10 @@ babel-plugin-filter-imports@~0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-filter-imports/-/babel-plugin-filter-imports-0.3.1.tgz#e7859b56886b175dd2616425d277b219e209ea8b"
 
+babel-plugin-glimmer-inline-precompile@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/babel-plugin-glimmer-inline-precompile/-/babel-plugin-glimmer-inline-precompile-1.1.0.tgz#31a2506c7085ec138754098a16e702acd4cefe67"
+
 babel-plugin-strip-glimmer-utils@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-strip-glimmer-utils/-/babel-plugin-strip-glimmer-utils-0.1.1.tgz#df74a4a349d0b8522f434c457cb6cef20483c9ea"

--- a/yarn.lock
+++ b/yarn.lock
@@ -66,9 +66,9 @@
   dependencies:
     "@glimmer/wire-format" "^0.26.2"
 
-"@glimmer/resolution-map-builder@^0.3.8":
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/@glimmer/resolution-map-builder/-/resolution-map-builder-0.3.8.tgz#9da5d9980f2cc0f149c060c2e767261eed25672d"
+"@glimmer/resolution-map-builder@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.npmjs.org/@glimmer/resolution-map-builder/-/resolution-map-builder-0.5.1.tgz#b07395f5d8d9a1d20f407169cd2d6b8cd48ab3f9"
   dependencies:
     broccoli-plugin "^1.3.0"
     silent-error "^1.0.1"


### PR DESCRIPTION
If `EMBER_ENV` is `test` then Rollup is run with `tests.js` as its entry file, where `tests.js` is a generated file importing all colocated `-test` files. Colocated means this:

```
src
└── ui
    └── components
        └── hello-glimmer
            ├── component-test.ts
            ├── component.ts
            └── template.hbs
```

Concerns like which test framework is used are left to the app/blueprint.

## To-do:

- [x] Make version of build for testing (this PR)
- [x] Land https://github.com/glimmerjs/resolution-map-builder/pull/25
- [x] Land https://github.com/glimmerjs/resolution-map-builder/pull/26
- [x] Land https://github.com/glimmerjs/glimmer-resolver/pull/15
- [x] Create babel-plugin-glimmer-inline-precompile
- [x] Incorporate https://github.com/glimmerjs/babel-plugin-glimmer-inline-precompile
- [x] Create `@glimmer/inline-precompile`
- [x] Land https://github.com/ember-cli/ember-build-utilities/pull/18
- [x] Release ember-build-utilities
- [x] Bump ember-build-utilities