### PR TITLE
Allow user-land babel plugins to be provided.

### DIFF
--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -26,8 +26,7 @@ const debugTree: (inputTree: Tree, name: string) => Tree = require('broccoli-deb
 
 import RollupWithDependencies from './rollup-with-dependencies';
 import defaultModuleConfiguration from './default-module-configuration';
-import { Project, Addon, Tree, RollupOptions } from '../interfaces';
-
+import { Project, Addon, Tree, RollupOptions, Registry, GlimmerAppOptions } from '../interfaces';
 
 export interface AbstractBuild {
   _notifyAddonIncluded(): void;
@@ -70,10 +69,6 @@ export interface AbstractBuild {
   package(jsTree: Tree, cssTree: Tree, publicTree: Tree, htmlTree: Tree): Tree;
 }
 
-export interface Registry {
-  add(type: string, plugin: Function)
-}
-
 export interface OutputPaths {
   app: {
     html: string;
@@ -83,23 +78,6 @@ export interface OutputPaths {
 }
 export interface EmberCLIDefaults {
   project: Project
-}
-
-export interface GlimmerAppOptions {
-  outputPaths?: {
-    app?: {
-      html?: string;
-      js?: string;
-      css?: string;
-    }
-  }
-  trees?: {
-    src?: Tree | string;
-    styles?: Tree | string;
-    nodeModules?: Tree | string;
-  }
-  registry?: Registry;
-  rollup?: RollupOptions;
 }
 
 export interface Trees {
@@ -124,7 +102,7 @@ export default class GlimmerApp extends AbstractBuild {
   private registry: Registry;
   private outputPaths: OutputPaths;
   private rollupOptions: RollupOptions;
-  protected options;
+  protected options: GlimmerAppOptions;
 
   protected trees: Trees;
 
@@ -380,7 +358,8 @@ Please run the following to resolve this warning:
     return new RollupWithDependencies(maybeDebug(jsTree, 'rollup-input-tree'), {
       inputFiles: ['**/*.js'],
       rollup: rollupOptions,
-      project: this.project
+      project: this.project,
+      buildConfig: this.options
     });
   }
 

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -42,3 +42,36 @@ export interface RollupOptions {
   external?: string[] | ((id: string) => boolean);
   paths?: { [importId: string]: string } | ((id: string) => string);
 }
+
+export interface Registry {
+  add(type: string, plugin: Function)
+}
+
+export type BabelPlugin = string | [string] | [string, any] | [any] | [any, any];
+
+export interface GlimmerAppOptions {
+  babel?: {
+    spec?: boolean;
+    loose?: boolean;
+    debug?: boolean;
+    include?: string[];
+    exclude?: string[];
+    useBuiltIns?: boolean;
+    plugins?: BabelPlugin[];
+  }
+  outputPaths?: {
+    app?: {
+      html?: string;
+      js?: string;
+      css?: string;
+    }
+  }
+  trees?: {
+    src?: Tree | string;
+    styles?: Tree | string;
+    nodeModules?: Tree | string;
+  }
+  registry?: Registry;
+  rollup?: RollupOptions;
+  sourcemaps?: { enabled?: boolean }
+}

--- a/tests/broccoli/glimmer-app-test.ts
+++ b/tests/broccoli/glimmer-app-test.ts
@@ -16,6 +16,8 @@ import { GlimmerAppOptions } from '../../lib/interfaces';
 const expect = require('../helpers/chai').expect;
 
 describe('glimmer-app', function() {
+  this.timeout(15000);
+
   let input: TempDir;
 
   const ORIGINAL_EMBER_ENV = process.env.EMBER_ENV;
@@ -415,7 +417,6 @@ describe('glimmer-app', function() {
   });
 
   describe('toTree', function() {
-    this.timeout(10000);
 
     const tsconfigContents = stripIndent`
       {


### PR DESCRIPTION
This enables users to include `babel-plugin-glimmer-inline-precompile`.