### PR TITLE
fix errors on passing broccoli nodes as app trees

### DIFF
--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -195,6 +195,8 @@ export default class GlimmerApp extends AbstractBuild {
     } else if (!rawSrcTree) {
       let srcPath = resolveLocal(root, 'src');
       srcTree = existsSync(srcPath) ? new WatchedDir(srcPath) : null;
+    } else {
+      srcTree = rawSrcTree;
     }
 
     if (srcTree) {
@@ -212,6 +214,8 @@ export default class GlimmerApp extends AbstractBuild {
     } else if (!rawStylesTree) {
       let stylesPath= resolveLocal(root, path.join('src', 'ui', 'styles'));
       stylesTree = existsSync(stylesPath) ? new WatchedDir(stylesPath) : null;
+    } else {
+      stylesTree = rawStylesTree;
     }
 
     if (stylesTree) {

--- a/tests/broccoli/glimmer-app-test.ts
+++ b/tests/broccoli/glimmer-app-test.ts
@@ -701,6 +701,30 @@ describe('glimmer-app', function() {
       expect(actual['app.js']).to.include('NOW YOU DON\'T');
     });
 
+    it('allows passing custom Broccoli nodes', async function() {
+      input.write({
+        'src': {
+          'index.ts': '',
+          'ui': {
+            'index.html': 'src'
+          }
+        },
+        'config': {},
+        'tsconfig.json': tsconfigContents
+      });
+
+      let app = createApp({
+        trees: {
+          src: stew.log(path.join(input.path(), 'src')),
+          nodeModules: path.join(__dirname, '..', '..', '..', 'node_modules')
+        },
+      });
+      let output = await buildOutput(app.toTree());
+      let actual = output.read();
+
+      expect(actual['app.js']).to.be.defined;
+    });
+
     describe('`getGlimmerEnvironment`', () => {
       it('returns application options from `config/environment.js` if it is specified via `GlimmerENV`', () => {
         input.write({


### PR DESCRIPTION
Passing anything other than a string as app trees in GlimmerApp options wasn't actually being handled. This fixes this so custom Broccoli nodes can be used.