### PR TITLE
Adds broccoli-file-creator as a project dpeendency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "broccoli-config-loader": "^1.0.0",
     "broccoli-config-replace": "^1.1.2",
     "broccoli-debug": "^0.6.2",
+    "broccoli-file-creator": "^1.1.1",
     "broccoli-merge-trees": "^2.0.0",
     "broccoli-persistent-filter": "^1.3.1",
     "broccoli-rollup": "^1.3.0",


### PR DESCRIPTION
The missing dependency is breaking new @glimmer/blueprint
applications.