### PR TITLE
[WIP] Provide custom tests/index.html.

### DIFF
--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -71,6 +71,7 @@ export interface GlimmerAppOptions {
     src?: Tree | string;
     styles?: Tree | string;
     public?: Tree | string;
+    tests?: Tree | string;
     nodeModules?: Tree | string;
   }
   registry?: Registry;


### PR DESCRIPTION
Currently, the test supported added to Glimmer.js apps uses QUnit 1.20. The reason for this is that we are relying on the default testem test page for QUnit from [here](https://github.com/testem/testem/blob/master/views/qunitrunner.mustache) (which uses `//code.jquery.com/qunit/qunit-1.20.0.js`).

This commit does the following:

* creates support for a `tests` tree, that at the moment only includes `tests/index.html`
* Ensures that when tests are built, we still build the "normal" app assets  (and `tests/index.js` / `tests/index.html` are generated)

There are still a number of things that should probably done here:

- [ ] Ensure QUnit itself is included into the `tests/index.js` (QUnit does not have a `module` entry point so it can't just automatically be rolled up...)
- [ ] Update existing tests for the asset location changes
- [ ] Add more tests to ensure the new functionality works properly
- [ ] Update to ensure that `tests` folder is not required (so that we are backwards compatible)