### PR TITLE
support generating `<Capital />` component names

### DIFF
--- a/blueprints/glimmer-component-test/index.js
+++ b/blueprints/glimmer-component-test/index.js
@@ -1,27 +1,23 @@
 'use strict';
 
-const stringUtils = require('ember-cli-string-utils');
-const validComponentName = require('ember-cli-valid-component-name');
-const normalizeEntityName = require('ember-cli-normalize-entity-name');
+const helpers = require('../helpers');
 
 module.exports = {
-  description: 'Generates a component test. Name must contain a hyphen.',
+  description: 'Generates a component test. Name must be capitalized.',
 
   normalizeEntityName(entityName) {
-    return validComponentName(normalizeEntityName(entityName));
+    return helpers.validComponentName(entityName);
   },
 
   fileMapTokens() {
     return {
       __name__(options) {
-        return options.dasherizedModuleName;
+        return options.locals.moduleName;
       },
     };
   },
 
   locals(options) {
-    let nameParts = options.entity.name.split('/');
-    let componentName = nameParts[nameParts.length - 1];
-    return { componentName };
+    return helpers.getComponentLocals(options.entity.name);
   },
 };

--- a/blueprints/glimmer-component/index.js
+++ b/blueprints/glimmer-component/index.js
@@ -1,28 +1,23 @@
 'use strict';
 
-const stringUtils = require('ember-cli-string-utils');
-const validComponentName = require('ember-cli-valid-component-name');
-const normalizeEntityName = require('ember-cli-normalize-entity-name');
+const helpers = require('../helpers');
 
 module.exports = {
-  description: 'Generates a component. Name must contain a hyphen.',
+  description: 'Generates a component. Name must be capitalized.',
 
   normalizeEntityName(entityName) {
-    return validComponentName(normalizeEntityName(entityName));
+    return helpers.validComponentName(entityName);
   },
 
   fileMapTokens() {
     return {
       __name__(options) {
-        return options.dasherizedModuleName;
+        return options.locals.moduleName;
       },
     };
   },
 
   locals(options) {
-    let nameParts = options.entity.name.split('/');
-    let baseName = nameParts[nameParts.length - 1];
-    let className = stringUtils.classify(baseName);
-    return { className };
+    return helpers.getComponentLocals(options.entity.name);
   },
 };

--- a/blueprints/helpers.js
+++ b/blueprints/helpers.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const stringUtils = require('ember-cli-string-utils');
+const SilentError = require('silent-error');
+
+function capitalize(name) {
+  return name[0].toUpperCase() + name.slice(1);
+};
+
+function validComponentName(entityName) {
+  let parts = entityName.split('/');
+  let name = parts[parts.length - 1];
+
+  let firstCharacter = name[0];
+  if(firstCharacter !== firstCharacter.toUpperCase()) {
+    throw new SilentError("Component name must be capitalized");
+  }
+
+  return entityName;
+};
+
+function getComponentLocals(entityName) {
+  let nameParts = entityName.split('/');
+  let baseName = nameParts[nameParts.length - 1];
+  let componentName = capitalize(baseName);
+  let className = stringUtils.classify(baseName);
+
+  nameParts.pop();
+  nameParts.push(componentName);
+  let moduleName = nameParts.join('/');
+
+  return { componentName, className, moduleName };
+};
+
+module.exports = {
+  capitalize,
+  validComponentName,
+  getComponentLocals
+};

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "ember-cli-normalize-entity-name": "^1.0.0",
     "ember-cli-preprocess-registry": "^3.1.1",
     "ember-cli-string-utils": "^1.1.0",
-    "ember-cli-valid-component-name": "^1.0.0",
     "exists-sync": "^0.0.4",
     "glob": "^7.1.2",
     "heimdalljs-logger": "^0.1.9",

--- a/tests/glimmer-component-test.ts
+++ b/tests/glimmer-component-test.ts
@@ -21,37 +21,54 @@ describe('Acceptance: ember generate and destroy glimmer-component', function() 
     });
   });
 
-  it('glimmer-component foo-bar', function () {
-    let args = ['glimmer-component', 'foo-bar'];
+  it('glimmer-component FooBar', function () {
+    let args = ['glimmer-component', 'FooBar'];
 
     return emberNew()
       .then(() => emberGenerateDestroy(args, (file) => {
-        expect(file('src/ui/components/foo-bar/component.ts'))
+        expect(file('src/ui/components/FooBar/component.ts'))
           .to.contain(`import Component from '@glimmer/component';`)
           .to.contain(`export default class FooBar extends Component {`);
 
-        expect(file('src/ui/components/foo-bar/template.hbs'))
+        expect(file('src/ui/components/FooBar/template.hbs'))
           .to.contain(`<div></div>`);
 
-        expect(file('src/ui/components/foo-bar/component.js')).to.not.exist;
-        expect(file('src/ui/components/foo-bar/helper.ts')).to.not.exist;
+        expect(file('src/ui/components/FooBar/component.js')).to.not.exist;
+        expect(file('src/ui/components/FooBar/helper.ts')).to.not.exist;
       }));
   });
 
-  it('glimmer-component foo/bar/x-baz', function () {
-    let args = ['glimmer-component', 'foo/bar/x-baz'];
+  it('glimmer-component foo/bar/X-Baz', function () {
+    let args = ['glimmer-component', 'foo/bar/X-Baz'];
 
     return emberNew()
       .then(() => emberGenerateDestroy(args, (file) => {
-        expect(file('src/ui/components/foo/bar/x-baz/component.ts'))
+        expect(file('src/ui/components/foo/bar/X-Baz/component.ts'))
           .to.contain(`import Component from '@glimmer/component';`)
           .to.contain(`export default class XBaz extends Component {`);
 
-        expect(file('src/ui/components/foo/bar/x-baz/template.hbs'))
+        expect(file('src/ui/components/foo/bar/X-Baz/template.hbs'))
           .to.contain(`<div></div>`);
 
-        expect(file('src/ui/components/foo/bar/x-baz/component.js')).to.not.exist;
-        expect(file('src/ui/components/foo/bar/x-baz/helper.ts')).to.not.exist;
+        expect(file('src/ui/components/foo/bar/X-Baz/component.js')).to.not.exist;
+        expect(file('src/ui/components/foo/bar/X-Baz/helper.ts')).to.not.exist;
+      }));
+  });
+
+  it('glimmer-component X-Foo/X-Bar/X-Baz', function () {
+    let args = ['glimmer-component', 'X-Foo/X-Bar/X-Baz'];
+
+    return emberNew()
+      .then(() => emberGenerateDestroy(args, (file) => {
+        expect(file('src/ui/components/X-Foo/X-Bar/X-Baz/component.ts'))
+          .to.contain(`import Component from '@glimmer/component';`)
+          .to.contain(`export default class XBaz extends Component {`);
+
+        expect(file('src/ui/components/X-Foo/X-Bar/X-Baz/template.hbs'))
+          .to.contain(`<div></div>`);
+
+        expect(file('src/ui/components/X-Foo/X-Bar/X-Baz/component.js')).to.not.exist;
+        expect(file('src/ui/components/X-Foo/X-Bar/X-Baz/helper.ts')).to.not.exist;
       }));
   });
 });


### PR DESCRIPTION
adds support for generating `<Capital />` component names: https://emberjs.com/blog/2017/10/10/glimmer-progress-report.html#toc_adopting-code-capital-code-components

<img width="717" alt="screen shot 2017-10-11 at 22 07 00" src="https://user-images.githubusercontent.com/2526/31466853-96cae668-aed0-11e7-8924-50c8c5b850b4.png">

<img width="569" alt="screen shot 2017-10-11 at 22 06 28" src="https://user-images.githubusercontent.com/2526/31466857-9a11848a-aed0-11e7-9ade-e90794168dde.png">

<img width="1256" alt="screen shot 2017-10-11 at 21 47 07" src="https://user-images.githubusercontent.com/2526/31466733-2c1bb608-aed0-11e7-88f6-f96cec17c875.png">
(I think the yellow warnings are due to the fact that I'm pointing to a github branch)

---
/cc @tomdale @rwjblue 