### PR TITLE
Support bytecode compilation of templates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 
 node_js:
   - "8"
-  - "node"
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: node_js
 
 node_js:
-  - "4"
-  - "6"
-  - "7"
+  - "8"
   - "node"
 
 matrix:

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -2,25 +2,21 @@
 
 const path = require('path');
 const Funnel = require('broccoli-funnel');
-const compileTypescript = require('@glimmer/build/lib/compile-typescript');
+const MergeTrees = require('broccoli-merge-trees');
+const { TypeScriptPlugin } = require('broccoli-typescript-compiler');
 
 module.exports = function() {
-  let tsconfigPath = path.join(__dirname, 'tsconfig.json');
   let projectPath = __dirname;
 
   let libPath = path.join(projectPath, 'lib');
   let testsPath = path.join(projectPath, 'tests');
 
-  let srcTrees = [
+  let srcTrees = new MergeTrees([
     new Funnel(libPath, { destDir: 'lib' }),
     new Funnel(testsPath, { destDir: 'tests' })
-  ];
+  ]);
 
-  let compiledTypescript = compileTypescript(
-    tsconfigPath,
-    projectPath,
-    srcTrees
-  );
+  let compiledTypescript = new TypeScriptPlugin(srcTrees);
 
   return compiledTypescript;
 };

--- a/lib/broccoli/compilers/glimmer-json-compiler.ts
+++ b/lib/broccoli/compilers/glimmer-json-compiler.ts
@@ -1,0 +1,15 @@
+import { GlimmerTemplatePrecompiler, } from 'ember-build-utilities';
+import { Tree } from 'broccoli';
+
+/**
+ * Subclasses the Glimmer template compiler from ember-build-utilities to emit
+ * files with a `.js` extension instead of `.ts`.
+ */
+export default class GlimmerJSONCompiler extends GlimmerTemplatePrecompiler {
+  targetExtension: string;
+
+  constructor(inputNode: Tree, options: any) {
+    super(inputNode, options);
+    this.targetExtension = 'js';
+  }
+}

--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -546,12 +546,6 @@ export default class GlimmerApp extends AbstractBuild {
   }
 
   private buildResolutionMap(src: Tree) {
-    // if (this.templateFormat !== 'json') {
-    //   src = new Funnel(src, {
-    //     exclude: ['**/*.hbs']
-    //   });
-    // }
-
     return new ResolutionMapBuilder(src as any, this._configTree(), {
       srcDir: "src",
       configPath: this.configPath,

--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -1,6 +1,5 @@
 import path = require("path");
 import defaultsDeep = require("lodash.defaultsdeep");
-import existsSync = require("exists-sync");
 
 import { Tree } from "broccoli";
 import ConfigLoader = require("broccoli-config-loader");
@@ -13,11 +12,11 @@ import ConfigReplace = require("broccoli-config-replace");
 
 import ResolutionMapBuilder = require("@glimmer/resolution-map-builder");
 import ResolverConfigurationBuilder = require("@glimmer/resolver-configuration-builder");
+import { GlimmerBundleCompiler } from "@glimmer/app-compiler";
 
 import {
   Project,
   addonProcessTree,
-  GlimmerTemplatePrecompiler,
   resolveLocal,
   AbstractBuild,
   EmberCLIDefaults,
@@ -36,22 +35,10 @@ import maybeDebug from "./utils/maybe-debug";
 import normalizeTree from "./utils/normalize-tree"
 import { addonTreesFor, addonLintTree } from "./utils/addons";
 import RollupWithDependencies from "./rollup-with-dependencies";
+import GlimmerJSONCompiler from './compilers/glimmer-json-compiler';
 import defaultModuleConfiguration from "./default-module-configuration";
 import { GlimmerAppOptions } from "../interfaces";
 import TestEntrypointBuilder from "./test-entrypoint-builder";
-
-const DEFAULT_TS_OPTIONS = {
-  tsconfig: {
-    compilerOptions: {
-      target: "es5",
-      module: "es2015",
-      inlineSourceMap: true,
-      inlineSources: true,
-      moduleResolution: "node"
-    },
-    exclude: ["node_modules", "**/*.d.ts"]
-  }
-};
 
 export interface OutputPaths {
   app: {
@@ -89,13 +76,14 @@ class MissingProjectError extends Error {
  * @param {Object} [options=Options] Configuration options
  */
 export default class GlimmerApp extends AbstractBuild {
-  public project: Project;
+  public project!: Project;
   public name: string;
   public env: "production" | "development" | "test";
-  protected options: GlimmerAppOptions;
+  protected options!: GlimmerAppOptions;
   protected trees: Trees;
   protected registry: Registry;
   protected outputPaths: OutputPaths;
+  protected templateFormat: 'json' | 'bytecode';
 
   constructor(upstreamDefaults: EmberCLIDefaults, options: GlimmerAppOptions = {}) {
     if (arguments.length === 0 || !upstreamDefaults.project) {
@@ -116,6 +104,7 @@ export default class GlimmerApp extends AbstractBuild {
 
     this.trees = this.buildTrees(options);
     this.outputPaths = options.outputPaths as OutputPaths;
+    this.templateFormat = options.templateFormat!;
 
     this._notifyAddonIncluded();
   }
@@ -124,39 +113,60 @@ export default class GlimmerApp extends AbstractBuild {
     throw new Error("app.import is not yet implemented for GlimmerApp");
   }
 
-  /* Build Pipeline */
+  //
+  // USER HOOKS
+  //
 
   /**
-   * This hook is responsible for packaging assets together after they've been
-   * individually compiled. It receives the application's JavaScript as "loose
-   * modules" that are appropriate for bundling into optimized assets to be
-   * distributed to the browser, using a tool like webpack or Rollup (the
-   * default).
+   * This hook is responsible for compiling the application's files together
+   * after they've been individually processed. It receives the application's
+   * JavaScript as "loose modules" that are appropriate for bundling into
+   * optimized assets to be distributed to the browser, using a tool like
+   * webpack or Rollup (the default).
    */
-  public package(jsTree: Tree | null, cssTree: Tree | null, publicTree: Tree | null, htmlTree: Tree | null): Tree {
-    let trees: Tree[] = [];
+  public package(appTree: Tree): Tree {
+    let otherTrees: Tree[] = [];
 
-    if (jsTree) {
-      jsTree = this.rollupTree(jsTree);
-      trees.push(jsTree);
+    let jsTree: Tree = appTree;
+
+    if (this.emitBytecodeTemplates) {
+      let { gbxTree, dataSegmentTree } = this.compileTemplatesToBytecode(appTree);
+      jsTree = new MergeTrees([dataSegmentTree, appTree], { overwrite: true });
+      otherTrees.push(gbxTree);
     }
 
-    if (htmlTree) {
-      trees.push(htmlTree);
-    }
+    jsTree = this.rollupTree(jsTree);
 
-    if (cssTree) {
-      trees.push(cssTree);
-    }
+    appTree = new Funnel(appTree, {
+      exclude: ['**/*.js', '**/*.hbs']
+    });
 
-    if (publicTree) {
-      trees.push(publicTree);
-    }
+    let trees = [appTree, jsTree, ...otherTrees];
+    appTree = new MergeTrees(trees);
 
-    let appTree: Tree = new MergeTrees(trees);
     appTree = addonProcessTree(this.project, "postprocessTree", "all", appTree);
 
     return appTree;
+  }
+
+  /**
+   * Creates a Broccoli tree representing the compiled Glimmer application.
+   */
+  public toTree(): Tree {
+    if (this.env === "test") {
+      return this.testPackage();
+    }
+
+    let trees = [
+      this.javascriptTree(),
+      this.cssTree(),
+      this.hbsTree(),
+      this.htmlTree()
+    ].filter(Boolean) as Tree[];
+
+    let appTree = new MergeTrees(trees);
+
+    return new MergeTrees([this.publicTree(), this.package(appTree)]);
   }
 
   /**
@@ -206,7 +216,64 @@ export default class GlimmerApp extends AbstractBuild {
     };
   }
 
-  private cssTree(): Tree | null {
+  //
+  // TEMPLATE COMPILATION
+  //
+
+  /**
+   * True if the app should emit templates as Glimmer binary bytecode.
+   */
+  protected get emitBytecodeTemplates() {
+    return this.options.templateFormat === 'bytecode';
+  }
+
+  /**
+   * Given a Broccoli tree containing `.hbs` files, returns a tree with those
+   * templates transformed into their precompiled JSON form and saved as `.js`
+   * files.
+   */
+  protected compileTemplatesToJSON(appTree: Tree): Tree {
+    let glimmerEnv = this.getGlimmerEnvironment();
+    return new GlimmerJSONCompiler(appTree, {
+      rootName: this.project.pkg.name,
+      GlimmerENV: glimmerEnv
+    });
+  }
+
+  protected compileTemplatesToBytecode(appTree: Tree) {
+    let { project: { root } } = this;
+
+    // Template compiler needs access to root package.json
+    let pkgJsonTree = new UnwatchedDir(root);
+    pkgJsonTree = new Funnel(pkgJsonTree, {
+      include: ['package.json']
+    });
+
+    let templateTree: Tree = new MergeTrees([appTree, pkgJsonTree]);
+
+    let compiledOutput = new GlimmerBundleCompiler(templateTree, {
+      mode: 'module-unification',
+      outputFiles: {
+        heapFile: 'templates.gbx',
+        dataSegment: 'src/data-segment.js'
+      }
+    });
+
+    templateTree = new Funnel(compiledOutput, {
+      include: ['**/*.gbx']
+    });
+
+    let dataTree = new Funnel(compiledOutput, {
+      include: ['**/*.js']
+    });
+
+    return {
+      gbxTree: templateTree,
+      dataSegmentTree: dataTree
+    };
+  }
+
+  protected cssTree(): Tree | null {
     let { styles } = this.trees;
 
     if (!styles) { return null; }
@@ -236,7 +303,7 @@ export default class GlimmerApp extends AbstractBuild {
     );
   }
 
-  private publicTree() {
+  protected publicTree() {
     let trees = [
       ...addonTreesFor(this.project, "public"),
       this.trees.public
@@ -245,7 +312,7 @@ export default class GlimmerApp extends AbstractBuild {
     return new MergeTrees(trees as Tree[], { overwrite: true });
   }
 
-  public htmlTree() {
+  protected htmlTree() {
     let srcTree = this.trees.src;
 
     const htmlName = this.outputPaths.app.html;
@@ -271,7 +338,7 @@ export default class GlimmerApp extends AbstractBuild {
     });
   }
 
-  private contentFor(config: any, match: RegExp, type: string) {
+  protected contentFor(config: any, match: RegExp, type: string) {
     let content: string[] = [];
 
     switch (type) {
@@ -309,71 +376,64 @@ export default class GlimmerApp extends AbstractBuild {
     }];
   }
 
-  private tsOptions() {
-    let tsconfigPath = resolveLocal(this.project.root, "tsconfig.json");
-    let tsconfig;
+  /**
+   * Produces a Broccoli tree of all of the JavaScript files in the app as loose
+   * modules. Anything that is to be represented as JavaScript in the final
+   * output, such as TypeScript, should be transpiled here. Final packaging of
+   * the JavaScript modules happens in the `package()` hook.
+   */
+  protected javascriptTree(): Tree {
+    let { src: srcTree, nodeModules: nodeModulesTree } = this.trees;
 
-    if (existsSync(tsconfigPath)) {
-      try {
-        tsconfig = require(tsconfigPath);
-      } catch (err) {
-        console.log("Error reading from tsconfig.json");
-      }
-    } else {
-      console.log(
-        "No tsconfig.json found; falling back to default TypeScript settings."
-      );
-    }
-
-    return tsconfig ? { tsconfig } : DEFAULT_TS_OPTIONS;
-  }
-
-  private javascript(): Tree {
-    let { src, nodeModules } = this.trees;
-
-    let tsConfig = this.tsOptions();
-    let glimmerEnv = this.getGlimmerEnvironment();
-    let configTree = this.buildConfigTree(src!);
-    let srcWithoutHBSTree = new Funnel(src, {
-      exclude: ["**/*.hbs", "**/*.ts"]
-    });
-
-    // Compile the TypeScript and Handlebars files into JavaScript
-    let compiledHandlebarsTree = this.compiledHandlebarsTree(src!, glimmerEnv);
-    let combinedConfigAndCompiledHandlebarsTree = new MergeTrees([
-      configTree,
-      compiledHandlebarsTree
-    ]);
+    // Generate configuration files
+    let configTree: Tree = this.buildConfigTree(srcTree);
 
     // the output tree from typescript only includes the output from .ts -> .js transpilation
     // and no other files from the original source tree
-    let transpiledTypescriptTree = this.compiledTypeScriptTree(
-      combinedConfigAndCompiledHandlebarsTree,
-      nodeModules!,
-      tsConfig
-    );
+    let tsInput = new MergeTrees([configTree, srcTree, nodeModulesTree!]);
+    let tsTree = typescript(tsInput, {
+      workingPath: this.project.root
+    });
 
-    let trees = [srcWithoutHBSTree, transpiledTypescriptTree, configTree];
+    let jsTrees: Tree[] = [configTree, tsTree];
+
+    if (this.options.templateFormat === 'json') {
+      // Compile Handlebars templates to JavaScript
+      jsTrees.push(this.compileTemplatesToJSON(srcTree));
+    }
+
     if (this.env === "test") {
       const lintTrees = this.lint();
-      trees.push(
+      jsTrees.push(
         new TestEntrypointBuilder(
-          new MergeTrees([transpiledTypescriptTree, ...lintTrees])
+          new MergeTrees([tsTree, ...lintTrees])
         )
       );
-      trees.push(...lintTrees);
+      jsTrees.push(...lintTrees);
     }
 
     // Merge the JavaScript source and generated module map and resolver
     // configuration files together, making sure to overwrite the stub
     // module-map.js and resolver-configuration.js in the source tree with the
     // generated ones.
-    transpiledTypescriptTree = new MergeTrees(trees, { overwrite: true });
+    let jsTree: Tree = new MergeTrees(jsTrees, { overwrite: true });
 
-    return this.processESLastest(transpiledTypescriptTree);
+    jsTree = new Funnel(jsTree, {
+      include: ['**/*.js']
+    });
+
+    return this.processESLatest(jsTree);
   }
 
-  private processESLastest(tree: Tree): Tree {
+  private hbsTree(): Tree {
+    let { src } = this.trees;
+
+    return new Funnel(src, {
+      include: ['**/*.hbs']
+    });
+  }
+
+  private processESLatest(tree: Tree): Tree {
     return preprocessJs(tree, "/", this.name, {
       registry: this.registry
     });
@@ -385,34 +445,13 @@ export default class GlimmerApp extends AbstractBuild {
     return config.GlimmerENV || config.EmberENV;
   }
 
-  private testPackage(): Tree | null {
-    let jsTree = this.javascript();
-    if (!jsTree) {
-      return null;
-    }
+  private testPackage(): Tree {
+    let jsTree = this.javascriptTree();
 
     return this.rollupTree(jsTree, {
       entry: "src/utils/test-helpers/test-helper.js",
       dest: "index.js"
     });
-  }
-
-  /**
-   * Creates a Broccoli tree representing the compiled Glimmer application.
-   *
-   * @param options
-   */
-  public toTree() {
-    if (this.env === "test") {
-      return this.testPackage();
-    }
-
-    let jsTree = this.javascript();
-    let cssTree = this.cssTree();
-    let publicTree = this.publicTree();
-    let htmlTree = this.htmlTree();
-
-    return this.package(jsTree, cssTree, publicTree, htmlTree);
   }
 
   private lint() {
@@ -434,27 +473,6 @@ export default class GlimmerApp extends AbstractBuild {
     let lintedSrc = addonLintTree(this.project, "src", srcTree);
 
     return [lintedTemplates, lintedSrc];
-  }
-
-  private compiledTypeScriptTree(
-    srcTree: Tree,
-    nodeModulesTree: Tree,
-    tsConfig: {}
-  ): Tree {
-    let inputTrees = new MergeTrees([nodeModulesTree, srcTree]);
-
-    let compiledTypeScriptTree = typescript(inputTrees, tsConfig);
-
-    return maybeDebug(compiledTypeScriptTree, "typescript-output");
-  }
-
-  private compiledHandlebarsTree(srcTree: Tree, glimmerEnv: string) {
-    let compiledHandlebarsTree = new GlimmerTemplatePrecompiler(srcTree, {
-      rootName: this.project.pkg.name,
-      GlimmerENV: glimmerEnv
-    });
-
-    return maybeDebug(compiledHandlebarsTree, "handlebars-output");
   }
 
   private rollupTree(jsTree: Tree, options?: {}): Tree {
@@ -528,6 +546,12 @@ export default class GlimmerApp extends AbstractBuild {
   }
 
   private buildResolutionMap(src: Tree) {
+    // if (this.templateFormat !== 'json') {
+    //   src = new Funnel(src, {
+    //     exclude: ['**/*.hbs']
+    //   });
+    // }
+
     return new ResolutionMapBuilder(src as any, this._configTree(), {
       srcDir: "src",
       configPath: this.configPath,
@@ -614,7 +638,8 @@ function getDefaultOptions(upstream: EmberCLIDefaults, isProduction: boolean): E
       sourcemaps: {
         enabled: !isProduction
       },
-      storeConfigInMeta: null
+      storeConfigInMeta: null,
+      templateFormat: 'json'
     },
     upstream
   );

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -39,4 +39,5 @@ export interface GlimmerAppOptions {
   rollup?: RollupOptions;
   sourcemaps?: { enabled?: boolean };
   storeConfigInMeta?: boolean;
+  templateFormat?: 'json' | 'bytecode'
 }

--- a/lib/typings.d.ts
+++ b/lib/typings.d.ts
@@ -3,20 +3,12 @@ declare module "exists-sync" {
   export = existsSync;
 }
 
-declare module "broccoli-source" {
-  import Plugin = require('broccoli-plugin');
-
-  export class WatchedDir extends Plugin {
-    constructor(path: string);
-  }
-
-  export class UnwatchedDir {
-    constructor(path: string);
-  }
-}
+/**
+ * Broccoli
+ */
 
 declare module "broccoli" {
-  import Plugin = require("broccoli-plugin");
+  import Plugin from "broccoli-plugin";
   import { WatchedDir, UnwatchedDir } from "broccoli-source";
 
   export type Tree = string | Plugin | WatchedDir | UnwatchedDir;
@@ -29,11 +21,23 @@ declare module "broccoli-plugin" {
     build(): void;
   }
 
-  export = Plugin;
+  export default Plugin;
+}
+
+declare module "broccoli-source" {
+  import Plugin from "broccoli-plugin";
+
+  export class WatchedDir extends Plugin {
+    constructor(path: string);
+  }
+
+  export class UnwatchedDir {
+    constructor(path: string);
+  }
 }
 
 declare module "broccoli-caching-writer" {
-  import Plugin = require("broccoli-plugin");
+  import Plugin from "broccoli-plugin";
   import { Tree } from "broccoli";
 
   class CachingWriterPlugin extends Plugin {
@@ -42,8 +46,6 @@ declare module "broccoli-caching-writer" {
 
   export = CachingWriterPlugin;
 }
-
-declare module "babel-plugin-debug-macros";
 
 declare module "broccoli-debug" {
   import { Tree } from "broccoli";
@@ -112,6 +114,52 @@ declare module "broccoli-file-creator" {
   export = writeFile;
 }
 
+declare module "broccoli-merge-trees" {
+  import { Tree } from "broccoli";
+  import Plugin from "broccoli-plugin";
+
+  interface MergeTreesOptions {
+    overwrite?: boolean;
+  }
+
+  class MergeTrees extends Plugin {
+    constructor(trees: Tree[], options?: MergeTreesOptions);
+  }
+
+  export = MergeTrees;
+}
+
+declare module "broccoli-rollup" {
+  import Plugin from "broccoli-plugin";
+  import { Tree } from "broccoli";
+
+  class Rollup extends Plugin {
+    constructor(tree: Tree, options: any);
+  }
+
+  export = Rollup;
+}
+
+/**
+ * Babel Plugins
+ */
+
+declare module "babel-preset-env";
+declare module "babel-plugin-debug-macros";
+declare module "babel-plugin-external-helpers";
+declare module "babel-plugin-glimmer-inline-precompile";
+
+/**
+ * Rollup Plugins
+ */
+
+declare module "rollup-plugin-node-resolve";
+declare module "rollup-plugin-babel";
+
+/**
+ * Glimmer
+ */
+
 declare module "@glimmer/resolution-map-builder" {
   import { Tree } from "broccoli";
 
@@ -144,45 +192,9 @@ declare module "@glimmer/resolver-configuration-builder" {
 
   export = ResolverConfigurationBuilder;
 }
-
-declare module "ember-cli-blueprint-test-helpers/helpers" {
-  type FileHelper = (path: string) => string;
-
-  export function emberGenerateDestroy(args: string[], cb: (file: FileHelper) => void): Promise<void>;
-  export function emberGenerate(args: string[]): Promise<void>;
-  export function emberNew(): Promise<void>;
-  export function setupTestHooks(ctx: Mocha.ISuiteCallbackContext): void;
-}
-
-declare module "broccoli-rollup" {
-  import Plugin = require("broccoli-plugin");
-  import { Tree } from "broccoli";
-
-  class Rollup extends Plugin {
-    constructor(tree: Tree, options: any);
-  }
-
-  export = Rollup;
-}
-
-declare module "ember-cli-blueprint-test-helpers/chai" {
-  export { expect } from "chai";
-}
-
-declare module "broccoli-merge-trees" {
-  import { Tree } from "broccoli";
-  import Plugin = require("broccoli-plugin");
-
-  interface MergeTreesOptions {
-    overwrite?: boolean;
-  }
-
-  class MergeTrees extends Plugin {
-    constructor(trees: Tree[], options?: MergeTreesOptions);
-  }
-
-  export = MergeTrees;
-}
+/**
+ * Ember CLI
+ */
 
 declare module "ember-cli-preprocess-registry/preprocessors" {
   import { AbstractBuild } from "ember-build-utilities";
@@ -196,6 +208,19 @@ declare module "ember-cli-preprocess-registry/preprocessors" {
   export function defaultRegistry(app: AbstractBuild): Registry;
   export function preprocessJs(jsTree: Tree, inputPath: string, outputPath: string, options: any): Tree;
   export function preprocessCss(cssTree: Tree, inputPath: string, outputPath: string, options: any): Tree;
+}
+
+declare module "ember-cli-blueprint-test-helpers/chai" {
+  export { expect } from "chai";
+}
+
+declare module "ember-cli-blueprint-test-helpers/helpers" {
+  type FileHelper = (path: string) => string;
+
+  export function emberGenerateDestroy(args: string[], cb: (file: FileHelper) => void): Promise<void>;
+  export function emberGenerate(args: string[]): Promise<void>;
+  export function emberNew(): Promise<void>;
+  export function setupTestHooks(ctx: Mocha.ISuiteCallbackContext): void;
 }
 
 declare module "ember-build-utilities" {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "ember-addon"
   ],
   "dependencies": {
+    "@glimmer/app-compiler": "^0.9.0",
     "@glimmer/resolution-map-builder": "^0.5.1",
     "@glimmer/resolver-configuration-builder": "^0.1.2",
     "babel-plugin-debug-macros": "^0.1.7",
@@ -44,7 +45,7 @@
     "broccoli-rollup": "^1.3.0",
     "broccoli-source": "^1.1.0",
     "broccoli-string-replace": "^0.1.1",
-    "broccoli-typescript-compiler": "^2.1.1",
+    "broccoli-typescript-compiler": "^2.2.0",
     "common-tags": "^1.4.0",
     "ember-build-utilities": "^0.4.0",
     "ember-cli-inject-live-reload": "^1.4.1",
@@ -57,13 +58,13 @@
     "lodash.defaultsdeep": "^4.6.0",
     "rollup": "^0.41.6",
     "rollup-plugin-babel": "^2.7.1",
-    "rollup-plugin-node-resolve": "^2.0.0",
+    "rollup-plugin-node-resolve": "^3.0.2",
     "silent-error": "^1.1.0",
     "walk-sync": "^0.3.1"
   },
   "devDependencies": {
-    "@glimmer/build": "^0.8.4",
-    "@glimmer/compiler": "^0.31.0",
+    "@glimmer/application": "^0.9.0",
+    "@glimmer/component": "^0.9.0",
     "@glimmer/inline-precompile": "^1.0.1",
     "@glimmer/resolver": "^0.4.2",
     "@types/babel-traverse": "^6.25.3",
@@ -80,8 +81,9 @@
     "ember-cli": "^2.13.1",
     "ember-cli-blueprint-test-helpers": "^0.17.2",
     "mocha": "^3.4.1",
+    "simple-dom": "^1.4.0-alpha.82914663",
     "testdouble": "^2.1.2",
-    "typescript": "~2.6.0"
+    "typescript": "~2.7.0"
   },
   "ember-addon": {
     "main": "ember-cli-addon.js"

--- a/tests/broccoli/bytecode-templates-test.ts
+++ b/tests/broccoli/bytecode-templates-test.ts
@@ -1,0 +1,150 @@
+import GlimmerApp from '../../lib/broccoli/glimmer-app';
+import { GlimmerAppOptions } from '../../lib/interfaces';
+import { buildOutput, createTempDir, TempDir } from 'broccoli-test-helper';
+import path = require('path');
+import { readFileSync } from 'fs';
+import * as SimpleDOM from 'simple-dom';
+
+const expect = require('../helpers/chai').expect;
+const MockCLI = require('ember-cli/tests/helpers/mock-cli');
+const Project = require('ember-cli/lib/models/project');
+const { stripIndent } = require('common-tags');
+
+describe('Bytecode Template Compilation', function() {
+  this.timeout(20000);
+
+  let input: TempDir;
+  const pkg = {
+    name: 'glimmer-app-test',
+    version: '0.1.0'
+  };
+
+  beforeEach(function() {
+    return createTempDir().then(tempDir => (input = tempDir));
+  });
+
+  function createApp(options: GlimmerAppOptions = {}, addons: any[] = []): GlimmerApp {
+    let cli = new MockCLI();
+    let project = new Project(input.path(), pkg, cli.ui, cli);
+    project.initializeAddons();
+    project.addons = project.addons.concat(addons);
+
+    return new GlimmerApp({
+      project
+    }, options);
+  }
+
+  const tsconfigContents = stripIndent`
+    {
+      "compilerOptions": {
+        "target": "es6",
+        "module": "es2015",
+        "inlineSourceMap": true,
+        "inlineSources": true,
+        "moduleResolution": "node",
+        "experimentalDecorators": true
+      },
+      "exclude": [
+        "node_modules",
+        "tmp",
+        "dist"
+      ]
+    }
+  `;
+
+  const indexTsContents = stripIndent`
+    import Application, { BytecodeLoader, DOMBuilder, SyncRenderer } from '@glimmer/application';
+    import { ComponentManager, setPropertyDidChange } from '@glimmer/component';
+    import Resolver, { BasicModuleRegistry } from '@glimmer/resolver';
+    import resolverConfiguration from '../config/resolver-configuration';
+    import data from './data-segment';
+
+    exports = function(bytecode, document) {
+      const moduleRegistry = new BasicModuleRegistry(data.meta);
+      const resolver = new Resolver(resolverConfiguration, moduleRegistry);
+
+      const app = new Application({
+        document,
+        builder: new DOMBuilder({ element: document.body, nextSibling: null }),
+        loader: new BytecodeLoader({ bytecode, data }),
+        renderer: new SyncRenderer(),
+        resolver,
+        rootName: resolverConfiguration.app.rootName
+      });
+
+      app.registerInitializer({
+        initialize(registry) {
+          registry.register(\`component-manager:/\${app.rootName}/component-managers/main\`, ComponentManager);
+        }
+      });
+
+      return app;
+    };
+  `
+
+  it('produces functional bytecode output', async function() {
+    input.write({
+      'package.json': JSON.stringify(pkg),
+      'config': {
+        'resolver-configuration.d.ts': `declare var _default: any; export default _default;`
+      },
+      'src': {
+        'index.ts': indexTsContents,
+        'data-segment.d.ts': `declare var _default: any; export default _default;`,
+        'ui': {
+          'index.html': 'src',
+          'components': {
+            'App': {
+              'template.hbs': `<div>Hello!</div>`,
+              'component.ts': `import Component from "@glimmer/component"; export default class extends Component { };`
+            }
+          }
+        }
+      },
+      'tsconfig.json': tsconfigContents
+    });
+
+    let app = createApp({
+      templateFormat: 'bytecode',
+      trees: {
+        nodeModules: path.join(__dirname, '..', '..', '..', 'node_modules')
+      }
+    });
+
+    let output = await buildOutput(app.toTree());
+    let actual = output.read();
+
+    let bytecode = readFileAsArrayBuffer(output.path('templates.gbx'));
+    let buildApp = evalModule(actual['app.js'] as string);
+
+    let doc = new SimpleDOM.Document();
+    let glimmerApp = buildApp(bytecode, doc);
+
+    glimmerApp.renderComponent('App', doc.body, null);
+    await glimmerApp.boot();
+
+    let serializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
+    let html = serializer.serializeChildren(doc.body as any).trim();
+    expect(html).to.equal('<div>Hello!</div><!---->');
+  });
+});
+
+/**
+ * Reads a file and converts the returned Node buffer into an ArrayBuffer.
+ */
+function readFileAsArrayBuffer(filePath: string) {
+  let nodeBuffer = readFileSync(filePath);
+  let arrayBuf = new ArrayBuffer(nodeBuffer.length);
+  let bytes = new Uint8Array(arrayBuf);
+  bytes.set(nodeBuffer);
+
+  return arrayBuf;
+}
+
+function evalModule(source: string): any {
+  const wrapper = `(function(exports) { ${source}; return exports; })`;
+  const func = eval(wrapper);
+  const moduleExports = func({});
+
+  return moduleExports;
+}

--- a/tests/broccoli/glimmer-app-test.ts
+++ b/tests/broccoli/glimmer-app-test.ts
@@ -148,6 +148,7 @@ describe('glimmer-app', function() {
     it('invokes lintTree hook on addons', async function() {
       input.write({
         'src': {
+          'index.ts': 'export default {};',
           'ui': {
             'index.html': 'src',
           },
@@ -245,7 +246,7 @@ describe('glimmer-app', function() {
       });
 
       let app = createApp();
-      let output = await buildOutput(app.htmlTree());
+      let output = await buildOutput(app['htmlTree']());
 
       expect(output.read()).to.deep.equal({
         'index.html': 'src',
@@ -352,7 +353,7 @@ describe('glimmer-app', function() {
           }
         },
         'src': {
-          'index.ts': '',
+          'index.ts': 'export default {};',
           'ui': {
             'index.html': 'src'
           },
@@ -377,7 +378,7 @@ describe('glimmer-app', function() {
       input.write({
         'app': {},
         'src': {
-          'index.ts': '',
+          'index.ts': 'export default {};',
           'ui': {
             'index.html': 'src',
           },
@@ -400,7 +401,7 @@ describe('glimmer-app', function() {
       input.write({
         'app': {},
         'src': {
-          'index.ts': '',
+          'index.ts': 'export default {};',
           'ui': {
             'index.html': '',
             'styles': {
@@ -426,7 +427,7 @@ describe('glimmer-app', function() {
       input.write({
         'app': {},
         'src': {
-          'index.ts': '',
+          'index.ts': 'console.log("hello world");',
           'ui': {
             'index.html': '',
             'styles': {
@@ -490,7 +491,7 @@ describe('glimmer-app', function() {
           'ui': {
             'components': {
               'foo-bar': {
-                'template.d.ts': 'export default {};',
+                'template.d.ts': 'declare const _d: {}; export default _d;',
                 'template.hbs': `<div>Hello!</div>`,
                 'component.ts': 'console.log("qux"); export default class FooBar {}',
                 'component-test.ts': 'import template from "./template"; import FooBar from "./component"; console.log(template); console.log(FooBar);'
@@ -750,7 +751,7 @@ describe('glimmer-app', function() {
     it('honors outputPaths.app.js', async function() {
       input.write({
         'src': {
-          'index.ts': '',
+          'index.ts': 'console.log("hello world");',
           'ui': {
             'index.html': 'src'
           }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,49 +2,64 @@
 # yarn lockfile v1
 
 
-"@glimmer/build@^0.8.4":
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/@glimmer/build/-/build-0.8.4.tgz#86445a114237c3374b3327579f5c3e2f38544292"
+"@glimmer/app-compiler@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/app-compiler/-/app-compiler-0.9.0.tgz#058baa6537da27a2fa7226dae84e0dc8f5d88b7d"
   dependencies:
-    "@types/qunit" "^1.16.30"
-    amd-name-resolver "0.0.6"
-    babel-generator "^6.19.0"
-    babel-helpers "^6.16.0"
-    babel-plugin-check-es2015-constants "^6.8.0"
-    babel-plugin-debug-macros "^0.1.1"
-    babel-plugin-external-helpers "^6.22.0"
-    babel-plugin-feature-flags "^0.3.0"
-    babel-plugin-filter-imports "~0.3.0"
-    babel-plugin-strip-glimmer-utils "^0.1.1"
-    babel-plugin-transform-es2015-arrow-functions "^6.8.0"
-    babel-plugin-transform-es2015-block-scoping "^6.14.0"
-    babel-plugin-transform-es2015-classes "^6.14.0"
-    babel-plugin-transform-es2015-computed-properties "^6.8.0"
-    babel-plugin-transform-es2015-destructuring "^6.9.0"
-    babel-plugin-transform-es2015-modules-commonjs "^6.18.0"
-    babel-plugin-transform-es2015-parameters "^6.11.4"
-    babel-plugin-transform-es2015-shorthand-properties "^6.8.0"
-    babel-plugin-transform-es2015-spread "^6.8.0"
-    babel-plugin-transform-es2015-template-literals "^6.8.0"
-    babel-plugin-transform-proto-to-assign "^6.9.0"
-    babel-types "^6.19.0"
-    broccoli "^1.1.0"
-    broccoli-babel-transpiler "^6.0.0"
-    broccoli-cli "^1.0.0"
-    broccoli-concat "^3.0.5"
-    broccoli-file-creator "^1.1.1"
-    broccoli-funnel "^1.1.0"
-    broccoli-merge-trees "^1.2.1"
-    broccoli-rollup "^1.0.3"
-    broccoli-string-replace "^0.1.1"
-    broccoli-typescript-compiler "2.1.1"
-    loader.js "^4.0.11"
-    qunit "^2.4.1"
-    resolve "^1.3.2"
-    stack-trace "^0.0.9"
-    testem "^1.13.0"
-    tslint "^5.9.1"
-    typescript "~2.6.1"
+    "@glimmer/application" "^0.9.0"
+    "@glimmer/bundle-compiler" "^0.31.0"
+    "@glimmer/compiler-delegates" "^0.9.0"
+    "@glimmer/interfaces" "^0.31.0"
+    "@glimmer/opcode-compiler" "^0.31.0"
+    broccoli-plugin "^1.3.0"
+    debug "^3.1.0"
+    walk-sync "^0.3.2"
+
+"@glimmer/application@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/application/-/application-0.9.0.tgz#c0c8fa4073b1a650dbda5a3f82749c25b00dac27"
+  dependencies:
+    "@glimmer/compiler" "^0.31.0"
+    "@glimmer/component" "^0.9.0"
+    "@glimmer/di" "^0.1.9"
+    "@glimmer/env" "^0.1.7"
+    "@glimmer/interfaces" "^0.31.0"
+    "@glimmer/object-reference" "^0.31.0"
+    "@glimmer/opcode-compiler" "^0.31.0"
+    "@glimmer/reference" "^0.31.0"
+    "@glimmer/resolver" "^0.3.0"
+    "@glimmer/runtime" "^0.31.0"
+    "@glimmer/util" "^0.31.0"
+
+"@glimmer/bundle-compiler@^0.31.0":
+  version "0.31.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/bundle-compiler/-/bundle-compiler-0.31.0.tgz#a3eecfa0ec305798bc23739a830b201a168a0794"
+  dependencies:
+    "@glimmer/compiler" "^0.31.0"
+    "@glimmer/interfaces" "^0.31.0"
+    "@glimmer/opcode-compiler" "^0.31.0"
+    "@glimmer/program" "^0.31.0"
+    "@glimmer/syntax" "^0.31.0"
+    "@glimmer/util" "^0.31.0"
+    "@glimmer/wire-format" "^0.31.0"
+    simple-html-tokenizer "^0.4.1"
+
+"@glimmer/compiler-delegates@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/compiler-delegates/-/compiler-delegates-0.9.0.tgz#edb7677645ab0b7699c40a27d5884c82b6f542fd"
+  dependencies:
+    "@glimmer/application" "^0.9.0"
+    "@glimmer/bundle-compiler" "^0.31.0"
+    "@glimmer/component" "^0.9.0"
+    "@glimmer/interfaces" "^0.31.0"
+    "@glimmer/opcode-compiler" "^0.31.0"
+    "@glimmer/program" "^0.31.0"
+    "@glimmer/syntax" "^0.31.0"
+    "@glimmer/util" "^0.31.0"
+    "@types/node" "^8.0.46"
+    debug "^3.1.0"
+    glimmer-analyzer "^0.3.2"
+    resolve "^1.4.0"
 
 "@glimmer/compiler@^0.31.0":
   version "0.31.0"
@@ -56,9 +71,31 @@
     "@glimmer/wire-format" "^0.31.0"
     simple-html-tokenizer "^0.4.1"
 
+"@glimmer/component@^0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/component/-/component-0.9.0.tgz#4d7f769f57d7bf478bc80797e9b0efb611d90180"
+  dependencies:
+    "@glimmer/di" "^0.1.9"
+    "@glimmer/env" "^0.1.7"
+    "@glimmer/reference" "^0.31.0"
+    "@glimmer/runtime" "^0.31.0"
+    "@glimmer/util" "^0.31.0"
+
+"@glimmer/di@^0.1.9":
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/@glimmer/di/-/di-0.1.11.tgz#a6878c07a13a2c2c76fcde598a5c97637bfc4280"
+
 "@glimmer/di@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@glimmer/di/-/di-0.2.0.tgz#73bfd4a6ee4148a80bf092e8a5d29bcac9d4ce7e"
+
+"@glimmer/encoder@^0.31.0":
+  version "0.31.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/encoder/-/encoder-0.31.0.tgz#a4daf4aea35aaec1373007169aea2f50e155e993"
+
+"@glimmer/env@^0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
 
 "@glimmer/inline-precompile@^1.0.1":
   version "1.0.1"
@@ -66,11 +103,61 @@
   dependencies:
     babel-plugin-glimmer-inline-precompile "^1.2.0"
 
+"@glimmer/interfaces@^0.29.10":
+  version "0.29.10"
+  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.29.10.tgz#7744451ca329a42c62b08fa460808bccbddeb2ab"
+  dependencies:
+    "@glimmer/wire-format" "^0.29.10"
+
 "@glimmer/interfaces@^0.31.0":
   version "0.31.0"
   resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.31.0.tgz#642764765b266d5cf921f64354e06a3112551081"
   dependencies:
     "@glimmer/wire-format" "^0.31.0"
+
+"@glimmer/low-level@^0.31.0":
+  version "0.31.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/low-level/-/low-level-0.31.0.tgz#c5ed9c825fa67498f5285e8fe8003ec54d58d826"
+
+"@glimmer/object-reference@^0.31.0":
+  version "0.31.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/object-reference/-/object-reference-0.31.0.tgz#c1152ef0d9ce86a8fb7fa21107e3f99943c66ded"
+  dependencies:
+    "@glimmer/reference" "^0.31.0"
+    "@glimmer/util" "^0.31.0"
+
+"@glimmer/opcode-compiler@^0.31.0":
+  version "0.31.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/opcode-compiler/-/opcode-compiler-0.31.0.tgz#a25aa9bed6d3cbdde4bae3b7fc02a91d4fdd1e4e"
+  dependencies:
+    "@glimmer/encoder" "^0.31.0"
+    "@glimmer/interfaces" "^0.31.0"
+    "@glimmer/program" "^0.31.0"
+    "@glimmer/util" "^0.31.0"
+    "@glimmer/vm" "^0.31.0"
+    "@glimmer/wire-format" "^0.31.0"
+
+"@glimmer/program@^0.31.0":
+  version "0.31.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/program/-/program-0.31.0.tgz#0a535154d52ca14f821f70880ec8eb12dc1830de"
+  dependencies:
+    "@glimmer/encoder" "^0.31.0"
+    "@glimmer/interfaces" "^0.31.0"
+    "@glimmer/util" "^0.31.0"
+
+"@glimmer/reference@^0.31.0":
+  version "0.31.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/reference/-/reference-0.31.0.tgz#b4908e4549f54fec69d2a4b515c4e75c78b7a363"
+  dependencies:
+    "@glimmer/util" "^0.31.0"
+
+"@glimmer/resolution-map-builder@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/resolution-map-builder/-/resolution-map-builder-0.4.0.tgz#b999b51ea3046a44b323e7ef3683c22c99807ee3"
+  dependencies:
+    broccoli-plugin "^1.3.0"
+    silent-error "^1.0.1"
+    walk-sync "^0.3.1"
 
 "@glimmer/resolution-map-builder@^0.5.1":
   version "0.5.1"
@@ -86,11 +173,39 @@
   dependencies:
     broccoli-plugin "^1.3.0"
 
+"@glimmer/resolver@^0.3.0":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/resolver/-/resolver-0.3.1.tgz#41069345b6f41beb0948cc35d8e4aa60adcadfc5"
+  dependencies:
+    "@glimmer/di" "^0.2.0"
+
 "@glimmer/resolver@^0.4.2":
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/@glimmer/resolver/-/resolver-0.4.2.tgz#60c9b492e90bc3956ac82b3134649bd337e1651c"
   dependencies:
     "@glimmer/di" "^0.2.0"
+
+"@glimmer/runtime@^0.31.0":
+  version "0.31.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/runtime/-/runtime-0.31.0.tgz#6c668a053156e7ed2e8573acc5bed3bfd238b6a8"
+  dependencies:
+    "@glimmer/interfaces" "^0.31.0"
+    "@glimmer/low-level" "^0.31.0"
+    "@glimmer/opcode-compiler" "^0.31.0"
+    "@glimmer/program" "^0.31.0"
+    "@glimmer/reference" "^0.31.0"
+    "@glimmer/util" "^0.31.0"
+    "@glimmer/vm" "^0.31.0"
+    "@glimmer/wire-format" "^0.31.0"
+
+"@glimmer/syntax@^0.29.1":
+  version "0.29.10"
+  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.29.10.tgz#2a074223fc3b42d49c8b9345684a80b5133dc030"
+  dependencies:
+    "@glimmer/interfaces" "^0.29.10"
+    "@glimmer/util" "^0.29.10"
+    handlebars "^4.0.6"
+    simple-html-tokenizer "^0.4.1"
 
 "@glimmer/syntax@^0.31.0":
   version "0.31.0"
@@ -101,15 +216,59 @@
     handlebars "^4.0.6"
     simple-html-tokenizer "^0.4.1"
 
+"@glimmer/util@^0.29.10":
+  version "0.29.10"
+  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.29.10.tgz#8662daf273ffef9254b8d943d39aa396ed7225a5"
+
 "@glimmer/util@^0.31.0":
   version "0.31.0"
   resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.31.0.tgz#45e353a7dcaffe6df00cc3d729153ae6121cf0e4"
+
+"@glimmer/vm@^0.31.0":
+  version "0.31.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/vm/-/vm-0.31.0.tgz#5ea4b84723e184a869a09f6a24a3715eb9056599"
+  dependencies:
+    "@glimmer/interfaces" "^0.31.0"
+    "@glimmer/program" "^0.31.0"
+    "@glimmer/util" "^0.31.0"
+
+"@glimmer/wire-format@^0.29.10":
+  version "0.29.10"
+  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.29.10.tgz#90e82f67a6325468d6fee4f8dd7affc1070a9557"
+  dependencies:
+    "@glimmer/util" "^0.29.10"
 
 "@glimmer/wire-format@^0.31.0":
   version "0.31.0"
   resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.31.0.tgz#5a12e7a770a981ce9ea3a7daf737433bd6cd03d9"
   dependencies:
     "@glimmer/util" "^0.31.0"
+
+"@simple-dom/document@^1.4.0-alpha.82914663":
+  version "1.4.0-alpha.82914663"
+  resolved "https://registry.yarnpkg.com/@simple-dom/document/-/document-1.4.0-alpha.82914663.tgz#a88f70743ffe2dee664bc3e7be8657268229d3d1"
+  dependencies:
+    "@simple-dom/interface" "^1.4.0-alpha.82914663"
+
+"@simple-dom/interface@^1.4.0-alpha.82914663":
+  version "1.4.0-alpha.dc2f50c1"
+  resolved "https://registry.yarnpkg.com/@simple-dom/interface/-/interface-1.4.0-alpha.dc2f50c1.tgz#44d15bcf933b77d0740b91e9403042c8f32857c3"
+
+"@simple-dom/parser@^1.4.0-alpha.82914663":
+  version "1.4.0-alpha.82914663"
+  resolved "https://registry.yarnpkg.com/@simple-dom/parser/-/parser-1.4.0-alpha.82914663.tgz#3b2291a164823c37806800784cd52093459be336"
+  dependencies:
+    "@simple-dom/interface" "^1.4.0-alpha.82914663"
+
+"@simple-dom/serializer@^1.4.0-alpha.82914663":
+  version "1.4.0-alpha.82914663"
+  resolved "https://registry.yarnpkg.com/@simple-dom/serializer/-/serializer-1.4.0-alpha.82914663.tgz#8444de7207b175f48e8594bb948791075ffb1fb1"
+  dependencies:
+    "@simple-dom/interface" "^1.4.0-alpha.82914663"
+
+"@simple-dom/void-map@^1.4.0-alpha.82914663":
+  version "1.4.0-alpha.82914663"
+  resolved "https://registry.yarnpkg.com/@simple-dom/void-map/-/void-map-1.4.0-alpha.82914663.tgz#0669dd8d3a1cb3a391e548a139a3cdc327e07e09"
 
 "@types/babel-traverse@^6.25.3":
   version "6.25.3"
@@ -149,9 +308,9 @@
   version "7.0.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.18.tgz#cd67f27d3dc0cfb746f0bdd5e086c4c5d55be173"
 
-"@types/qunit@^1.16.30":
-  version "1.16.31"
-  resolved "https://registry.yarnpkg.com/@types/qunit/-/qunit-1.16.31.tgz#169ba79df56f25f40556c39c544e018bb6390792"
+"@types/node@^8.0.46":
+  version "8.9.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.9.2.tgz#94bb08914ea1aebbb18ecff4c27dc0930e512934"
 
 "@types/rsvp@^3.0.0":
   version "3.3.0"
@@ -193,12 +352,6 @@ align-text@^0.1.1, align-text@^0.1.3:
     kind-of "^3.0.2"
     longest "^1.0.1"
     repeat-string "^1.5.2"
-
-amd-name-resolver@0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/amd-name-resolver/-/amd-name-resolver-0.0.6.tgz#d3e4ba2dfcaab1d820c1be9de947c67828cfe595"
-  dependencies:
-    ensure-posix-path "^1.0.1"
 
 amd-name-resolver@1.0.0:
   version "1.0.0"
@@ -274,17 +427,9 @@ arr-diff@^2.0.0:
   dependencies:
     arr-flatten "^1.0.1"
 
-arr-diff@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
-
-arr-flatten@^1.0.1, arr-flatten@^1.1.0:
+arr-flatten@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
-
-arr-union@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
 
 array-binsearch@^1.0.1:
   version "1.0.1"
@@ -316,10 +461,6 @@ array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
 
-array-unique@^0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
-
 arraybuffer.slice@0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz#f33b2159f0532a3f3107a272c0ccfbd1ad2979ca"
@@ -340,10 +481,6 @@ assertion-error@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.0.2.tgz#13ca515d86206da0bac66e834dd397d87581094c"
 
-assign-symbols@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
-
 ast-types@0.9.6:
   version "0.9.6"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
@@ -359,10 +496,6 @@ async-disk-cache@^1.2.1:
     rimraf "^2.5.3"
     rsvp "^3.0.18"
     username-sync "1.0.1"
-
-async-each@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
 
 async-promise-queue@^1.0.3:
   version "1.0.4"
@@ -388,10 +521,6 @@ async@~0.2.9:
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
-
-atob@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/atob/-/atob-2.0.3.tgz#19c7a760473774468f20b2d2d03372ad7d4cbf5d"
 
 aws-sign2@~0.6.0:
   version "0.6.0"
@@ -456,19 +585,6 @@ babel-core@^6.14.0, babel-core@^6.26.0:
     private "^0.1.7"
     slash "^1.0.0"
     source-map "^0.5.6"
-
-babel-generator@^6.19.0:
-  version "6.24.0"
-  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.24.0.tgz#eba270a8cc4ce6e09a61be43465d7c62c1f87c56"
-  dependencies:
-    babel-messages "^6.23.0"
-    babel-runtime "^6.22.0"
-    babel-types "^6.23.0"
-    detect-indent "^4.0.0"
-    jsesc "^1.3.0"
-    lodash "^4.2.0"
-    source-map "^0.5.0"
-    trim-right "^1.0.1"
 
 babel-generator@^6.24.0, babel-generator@^6.26.0:
   version "6.26.1"
@@ -577,13 +693,6 @@ babel-helper-replace-supers@^6.24.1:
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
 
-babel-helpers@^6.16.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-helpers/-/babel-helpers-6.23.0.tgz#4f8f2e092d0b6a8808a4bde79c27f1e2ecf0d992"
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-template "^6.23.0"
-
 babel-helpers@^6.23.0, babel-helpers@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helpers/-/babel-helpers-6.24.1.tgz#3471de9caec388e5c850e597e58a26ddf37602b2"
@@ -597,13 +706,13 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-check-es2015-constants@^6.22.0, babel-plugin-check-es2015-constants@^6.8.0:
+babel-plugin-check-es2015-constants@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-debug-macros@^0.1.1, babel-plugin-debug-macros@^0.1.7:
+babel-plugin-debug-macros@^0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.1.7.tgz#69f5a3dc7d72f781354f18c611a3b007bb223511"
   dependencies:
@@ -615,21 +724,9 @@ babel-plugin-external-helpers@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-feature-flags@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-feature-flags/-/babel-plugin-feature-flags-0.3.1.tgz#9c827cf9a4eb9a19f725ccb239e85cab02036fc1"
-
-babel-plugin-filter-imports@~0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-filter-imports/-/babel-plugin-filter-imports-0.3.1.tgz#e7859b56886b175dd2616425d277b219e209ea8b"
-
 babel-plugin-glimmer-inline-precompile@^1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/babel-plugin-glimmer-inline-precompile/-/babel-plugin-glimmer-inline-precompile-1.2.0.tgz#02794b17aac6351da09596b54d9ec675428bba3e"
-
-babel-plugin-strip-glimmer-utils@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-strip-glimmer-utils/-/babel-plugin-strip-glimmer-utils-0.1.1.tgz#df74a4a349d0b8522f434c457cb6cef20483c9ea"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -651,7 +748,7 @@ babel-plugin-transform-async-to-generator@^6.22.0:
     babel-plugin-syntax-async-functions "^6.8.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-arrow-functions@^6.22.0, babel-plugin-transform-es2015-arrow-functions@^6.8.0:
+babel-plugin-transform-es2015-arrow-functions@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz#452692cb711d5f79dc7f85e440ce41b9f244d221"
   dependencies:
@@ -663,16 +760,6 @@ babel-plugin-transform-es2015-block-scoped-functions@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-block-scoping@^6.14.0:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz#76c295dc3a4741b1665adfd3167215dcff32a576"
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-template "^6.24.1"
-    babel-traverse "^6.24.1"
-    babel-types "^6.24.1"
-    lodash "^4.2.0"
-
 babel-plugin-transform-es2015-block-scoping@^6.23.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz#d70f5299c1308d05c12f463813b0a09e73b1895f"
@@ -683,7 +770,7 @@ babel-plugin-transform-es2015-block-scoping@^6.23.0:
     babel-types "^6.26.0"
     lodash "^4.17.4"
 
-babel-plugin-transform-es2015-classes@^6.14.0, babel-plugin-transform-es2015-classes@^6.23.0, babel-plugin-transform-es2015-classes@^6.9.0:
+babel-plugin-transform-es2015-classes@^6.23.0, babel-plugin-transform-es2015-classes@^6.9.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz#5a4c58a50c9c9461e564b4b2a3bfabc97a2584db"
   dependencies:
@@ -697,14 +784,14 @@ babel-plugin-transform-es2015-classes@^6.14.0, babel-plugin-transform-es2015-cla
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-computed-properties@^6.22.0, babel-plugin-transform-es2015-computed-properties@^6.8.0:
+babel-plugin-transform-es2015-computed-properties@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz#6fe2a8d16895d5634f4cd999b6d3480a308159b3"
   dependencies:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-plugin-transform-es2015-destructuring@^6.23.0, babel-plugin-transform-es2015-destructuring@^6.9.0:
+babel-plugin-transform-es2015-destructuring@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz#997bb1f1ab967f682d2b0876fe358d60e765c56d"
   dependencies:
@@ -745,15 +832,6 @@ babel-plugin-transform-es2015-modules-amd@^6.22.0, babel-plugin-transform-es2015
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-plugin-transform-es2015-modules-commonjs@^6.18.0:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz#d3e310b40ef664a36622200097c6d440298f2bfe"
-  dependencies:
-    babel-plugin-transform-strict-mode "^6.24.1"
-    babel-runtime "^6.22.0"
-    babel-template "^6.24.1"
-    babel-types "^6.24.1"
-
 babel-plugin-transform-es2015-modules-commonjs@^6.23.0, babel-plugin-transform-es2015-modules-commonjs@^6.24.1:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz#0d8394029b7dc6abe1a97ef181e00758dd2e5d8a"
@@ -786,7 +864,7 @@ babel-plugin-transform-es2015-object-super@^6.22.0:
     babel-helper-replace-supers "^6.24.1"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-parameters@^6.11.4, babel-plugin-transform-es2015-parameters@^6.23.0:
+babel-plugin-transform-es2015-parameters@^6.23.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz#57ac351ab49caf14a97cd13b09f66fdf0a625f2b"
   dependencies:
@@ -797,14 +875,14 @@ babel-plugin-transform-es2015-parameters@^6.11.4, babel-plugin-transform-es2015-
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-shorthand-properties@^6.22.0, babel-plugin-transform-es2015-shorthand-properties@^6.8.0:
+babel-plugin-transform-es2015-shorthand-properties@^6.22.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz#24f875d6721c87661bbd99a4622e51f14de38aa0"
   dependencies:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-spread@^6.22.0, babel-plugin-transform-es2015-spread@^6.8.0:
+babel-plugin-transform-es2015-spread@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz#d6d68a99f89aedc4536c81a542e8dd9f1746f8d1"
   dependencies:
@@ -818,7 +896,7 @@ babel-plugin-transform-es2015-sticky-regex@^6.22.0:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-plugin-transform-es2015-template-literals@^6.22.0, babel-plugin-transform-es2015-template-literals@^6.8.0:
+babel-plugin-transform-es2015-template-literals@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz#a84b3450f7e9f8f1f6839d6d687da84bb1236d8d"
   dependencies:
@@ -845,13 +923,6 @@ babel-plugin-transform-exponentiation-operator@^6.22.0:
     babel-helper-builder-binary-assignment-operator-visitor "^6.24.1"
     babel-plugin-syntax-exponentiation-operator "^6.8.0"
     babel-runtime "^6.22.0"
-
-babel-plugin-transform-proto-to-assign@^6.9.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-proto-to-assign/-/babel-plugin-transform-proto-to-assign-6.23.0.tgz#1c24951598793fc6a1d18118a11de1c36376fe2e"
-  dependencies:
-    babel-runtime "^6.22.0"
-    lodash "^4.2.0"
 
 babel-plugin-transform-regenerator@^6.22.0:
   version "6.26.0"
@@ -979,18 +1050,6 @@ base64id@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/base64id/-/base64id-0.1.0.tgz#02ce0fdeee0cef4f40080e1e73e834f0b1bfce3f"
 
-base@^0.11.1:
-  version "0.11.2"
-  resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
-  dependencies:
-    cache-base "^1.0.1"
-    class-utils "^0.3.5"
-    component-emitter "^1.2.1"
-    define-property "^1.0.0"
-    isobject "^3.0.1"
-    mixin-deep "^1.2.0"
-    pascalcase "^0.1.1"
-
 basic-auth@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.0.tgz#015db3f353e02e56377755f962742e8981e7bbba"
@@ -1008,10 +1067,6 @@ better-assert@~1.0.0:
   resolved "https://registry.yarnpkg.com/better-assert/-/better-assert-1.0.2.tgz#40866b9e1b9e0b55b481894311e68faffaebc522"
   dependencies:
     callsite "1.0.0"
-
-binary-extensions@^1.0.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.8.0.tgz#48ec8d16df4377eae5fa5884682480af4d95c774"
 
 "binaryextensions@1 || 2":
   version "2.1.1"
@@ -1094,22 +1149,6 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
-braces@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.0.tgz#a46941cb5fb492156b3d6a656e06c35364e3e66e"
-  dependencies:
-    arr-flatten "^1.1.0"
-    array-unique "^0.3.2"
-    define-property "^1.0.0"
-    extend-shallow "^2.0.1"
-    fill-range "^4.0.0"
-    isobject "^3.0.1"
-    repeat-element "^1.1.2"
-    snapdragon "^0.8.1"
-    snapdragon-node "^2.0.1"
-    split-string "^3.0.2"
-    to-regex "^3.0.1"
-
 broccoli-babel-transpiler@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/broccoli-babel-transpiler/-/broccoli-babel-transpiler-6.0.0.tgz#a52c5404bf36236849da503b011fd41fe64a00a2"
@@ -1170,13 +1209,7 @@ broccoli-clean-css@^1.1.0:
     inline-source-map-comment "^1.0.5"
     json-stable-stringify "^1.0.0"
 
-broccoli-cli@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/broccoli-cli/-/broccoli-cli-1.0.0.tgz#69444521a5e631569300fbc196e85e18097b22a4"
-  dependencies:
-    resolve "~0.6.1"
-
-broccoli-concat@^3.0.5, broccoli-concat@^3.2.2:
+broccoli-concat@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/broccoli-concat/-/broccoli-concat-3.2.2.tgz#86ffdc52606eb590ba9f6b894c5ec7a016f5b7b9"
   dependencies:
@@ -1246,7 +1279,7 @@ broccoli-funnel-reducer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel-reducer/-/broccoli-funnel-reducer-1.0.0.tgz#11365b2a785aec9b17972a36df87eef24c5cc0ea"
 
-broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.2.0:
+broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz#cddc3afc5ff1685a8023488fff74ce6fb5a51296"
   dependencies:
@@ -1284,7 +1317,7 @@ broccoli-funnel@^1.1.0:
     symlink-or-copy "^1.0.0"
     walk-sync "^0.3.1"
 
-broccoli-funnel@^2.0.0:
+broccoli-funnel@^2.0.0, broccoli-funnel@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz#6823c73b675ef78fffa7ab800f083e768b51d449"
   dependencies:
@@ -1316,7 +1349,7 @@ broccoli-kitchen-sink-helpers@^0.3.1:
     glob "^5.0.10"
     mkdirp "^0.5.1"
 
-broccoli-merge-trees@^1.0.0, broccoli-merge-trees@^1.2.1:
+broccoli-merge-trees@^1.0.0:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz#a001519bb5067f06589d91afa2942445a2d0fdb5"
   dependencies:
@@ -1401,7 +1434,7 @@ broccoli-plugin@^1.0.0, broccoli-plugin@^1.1.0, broccoli-plugin@^1.2.0, broccoli
     rimraf "^2.3.4"
     symlink-or-copy "^1.1.8"
 
-broccoli-rollup@^1.0.3, broccoli-rollup@^1.2.0, broccoli-rollup@^1.3.0:
+broccoli-rollup@^1.2.0, broccoli-rollup@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/broccoli-rollup/-/broccoli-rollup-1.3.0.tgz#43a0a7798555bab54217009eb470a4ff5a056df0"
   dependencies:
@@ -1470,18 +1503,18 @@ broccoli-test-helper@^1.1.0:
     rsvp "^3.3.3"
     walk-sync "^0.3.1"
 
-broccoli-typescript-compiler@2.1.1, broccoli-typescript-compiler@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/broccoli-typescript-compiler/-/broccoli-typescript-compiler-2.1.1.tgz#3d40d277c4804305cb8d4cd779137e44a4c16419"
+broccoli-typescript-compiler@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/broccoli-typescript-compiler/-/broccoli-typescript-compiler-2.2.0.tgz#7842f6a20ac802c1d0ac7f89963a251580d0612c"
   dependencies:
     array-binsearch "^1.0.1"
-    broccoli-funnel "^1.2.0"
+    broccoli-funnel "^2.0.1"
     broccoli-merge-trees "^2.0.0"
-    broccoli-plugin "^1.2.1"
-    fs-tree-diff "^0.5.2"
+    broccoli-plugin "^1.3.0"
+    fs-tree-diff "^0.5.7"
     heimdalljs "0.3.3"
     md5-hex "^2.0.0"
-    typescript "~2.6.1"
+    typescript "~2.7.1"
     walk-sync "^0.3.2"
 
 broccoli-writer@~0.1.1:
@@ -1511,12 +1544,6 @@ broccoli@^1.1.0:
     tmp "0.0.28"
     underscore.string "^3.2.2"
 
-browser-resolve@^1.11.0:
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.2.tgz#8ff09b0a2c421718a1051c260b32e48f442938ce"
-  dependencies:
-    resolve "1.1.7"
-
 browser-stdout@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
@@ -1544,7 +1571,7 @@ buffer-shims@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
 
-builtin-modules@^1.0.0, builtin-modules@^1.1.0, builtin-modules@^1.1.1:
+builtin-modules@^1.0.0, builtin-modules@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
@@ -1559,20 +1586,6 @@ bytes@1:
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
-
-cache-base@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
-  dependencies:
-    collection-visit "^1.0.0"
-    component-emitter "^1.2.1"
-    get-value "^2.0.6"
-    has-value "^1.0.0"
-    isobject "^3.0.1"
-    set-value "^2.0.0"
-    to-object-path "^0.3.0"
-    union-value "^1.0.0"
-    unset-value "^1.0.0"
 
 calculate-cache-key-for-tree@^1.0.0:
   version "1.1.0"
@@ -1691,30 +1704,6 @@ check-error@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
 
-chokidar@1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
-  dependencies:
-    anymatch "^1.3.0"
-    async-each "^1.0.0"
-    glob-parent "^2.0.0"
-    inherits "^2.0.1"
-    is-binary-path "^1.0.0"
-    is-glob "^2.0.0"
-    path-is-absolute "^1.0.0"
-    readdirp "^2.0.0"
-  optionalDependencies:
-    fsevents "^1.0.0"
-
-class-utils@^0.3.5:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
-  dependencies:
-    arr-union "^3.1.0"
-    define-property "^0.2.5"
-    isobject "^3.0.0"
-    static-extend "^0.1.1"
-
 clean-base-url@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/clean-base-url/-/clean-base-url-1.0.0.tgz#c901cf0a20b972435b0eccd52d056824a4351b7b"
@@ -1789,13 +1778,6 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-collection-visit@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
-  dependencies:
-    map-visit "^1.0.0"
-    object-visit "^1.0.0"
-
 color-convert@^1.9.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.1.tgz#c1261107aeb2f294ebffec9ed9ecad529a6097ed"
@@ -1824,10 +1806,6 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.12.2:
-  version "2.12.2"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.2.tgz#0f5946c427ed9ec0d91a46bb9def53e54650e555"
-
 commander@2.8.x:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.8.1.tgz#06be367febfda0c330aa1e2a072d3dc9762425d4"
@@ -1840,7 +1818,7 @@ commander@2.9.0, commander@^2.5.0:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
-commander@^2.12.1, commander@^2.6.0:
+commander@^2.6.0:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
 
@@ -1862,7 +1840,7 @@ component-emitter@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.1.2.tgz#296594f2753daa63996d2af08d15a95116c9aec3"
 
-component-emitter@1.2.1, component-emitter@^1.2.1:
+component-emitter@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
 
@@ -1969,10 +1947,6 @@ copy-dereference@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/copy-dereference/-/copy-dereference-1.0.0.tgz#6b131865420fd81b413ba994b44d3655311152b6"
 
-copy-descriptor@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
-
 core-js@^2.4.0, core-js@^2.5.0:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
@@ -1991,7 +1965,7 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cross-spawn@^5.0.0, cross-spawn@^5.0.1:
+cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:
@@ -2055,19 +2029,21 @@ debug@2.6.1:
   dependencies:
     ms "0.7.2"
 
-debug@2.6.9, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.4.0, debug@^2.6.8, debug@~2.6.7:
+debug@2.6.9, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.4.0, debug@^2.6.8, debug@~2.6.7:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  dependencies:
+    ms "2.0.0"
+
+debug@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
     ms "2.0.0"
 
 decamelize@^1.0.0, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
-
-decode-uri-component@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
 
 deep-eql@^0.1.3:
   version "0.1.3"
@@ -2078,18 +2054,6 @@ deep-eql@^0.1.3:
 deep-extend@~0.4.0:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.1.tgz#efe4113d08085f4e6f9687759810f807469e2253"
-
-define-property@^0.2.5:
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
-  dependencies:
-    is-descriptor "^0.1.0"
-
-define-property@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/define-property/-/define-property-1.0.0.tgz#769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6"
-  dependencies:
-    is-descriptor "^1.0.0"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -2116,10 +2080,6 @@ detect-file@^0.1.0:
   resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-0.1.0.tgz#4935dedfd9488648e006b0129566e9386711ea63"
   dependencies:
     fs-exists-sync "^0.1.0"
-
-detect-file@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
 
 detect-indent@^4.0.0:
   version "4.0.0"
@@ -2631,10 +2591,6 @@ execa@^0.9.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-exists-stat@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/exists-stat/-/exists-stat-1.0.0.tgz#0660e3525a2e89d9e446129440c272edfa24b529"
-
 exists-sync@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/exists-sync/-/exists-sync-0.0.3.tgz#b910000bedbb113b378b82f5f5a7638107622dcf"
@@ -2657,18 +2613,6 @@ expand-brackets@^0.1.4:
   dependencies:
     is-posix-bracket "^0.1.0"
 
-expand-brackets@^2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
-  dependencies:
-    debug "^2.3.3"
-    define-property "^0.2.5"
-    extend-shallow "^2.0.1"
-    posix-character-classes "^0.1.0"
-    regex-not "^1.0.0"
-    snapdragon "^0.8.1"
-    to-regex "^3.0.1"
-
 expand-range@^1.8.1:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/expand-range/-/expand-range-1.8.2.tgz#a299effd335fe2721ebae8e257ec79644fc85337"
@@ -2680,12 +2624,6 @@ expand-tilde@^1.2.2:
   resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-1.2.2.tgz#0b81eba897e5a3d31d1c3d102f8f01441e559449"
   dependencies:
     os-homedir "^1.0.1"
-
-expand-tilde@^2.0.0, expand-tilde@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-2.0.2.tgz#97e801aa052df02454de46b02bf621642cdc8502"
-  dependencies:
-    homedir-polyfill "^1.0.1"
 
 express@^4.10.7, express@^4.12.3:
   version "4.16.2"
@@ -2722,19 +2660,6 @@ express@^4.10.7, express@^4.12.3:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
-extend-shallow@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
-  dependencies:
-    is-extendable "^0.1.0"
-
-extend-shallow@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-3.0.2.tgz#26a71aaf073b39fb2127172746131c2704028db8"
-  dependencies:
-    assign-symbols "^1.0.0"
-    is-extendable "^1.0.1"
-
 extend@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
@@ -2756,19 +2681,6 @@ extglob@^0.3.1:
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
   dependencies:
     is-extglob "^1.0.0"
-
-extglob@^2.0.2:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
-  dependencies:
-    array-unique "^0.3.2"
-    define-property "^1.0.0"
-    expand-brackets "^2.1.4"
-    extend-shallow "^2.0.1"
-    fragment-cache "^0.2.1"
-    regex-not "^1.0.0"
-    snapdragon "^0.8.1"
-    to-regex "^3.0.1"
 
 extsprintf@1.0.2:
   version "1.0.2"
@@ -2835,15 +2747,6 @@ fill-range@^2.1.0:
     repeat-element "^1.1.2"
     repeat-string "^1.5.2"
 
-fill-range@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
-  dependencies:
-    extend-shallow "^2.0.1"
-    is-number "^3.0.0"
-    repeat-string "^1.6.1"
-    to-regex-range "^2.1.0"
-
 finalhandler@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.0.0.tgz#b5691c2c0912092f18ac23e9416bde5cd7dc6755"
@@ -2885,15 +2788,6 @@ find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
-findup-sync@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-2.0.0.tgz#9326b1488c22d1a6088650a86901b2d9a90a2cbc"
-  dependencies:
-    detect-file "^1.0.0"
-    is-glob "^3.1.0"
-    micromatch "^3.0.4"
-    resolve-dir "^1.0.1"
-
 findup-sync@^0.4.2:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-0.4.3.tgz#40043929e7bc60adf0b7f4827c4c6e75a0deca12"
@@ -2926,7 +2820,7 @@ fixturify@^0.3.2, fixturify@^0.3.3:
   dependencies:
     fs-extra "^0.30.0"
 
-for-in@^1.0.1, for-in@^1.0.2:
+for-in@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
 
@@ -2951,12 +2845,6 @@ form-data@~2.1.1:
 forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
-
-fragment-cache@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
-  dependencies:
-    map-cache "^0.2.2"
 
 fresh@0.5.2:
   version "0.5.2"
@@ -3028,7 +2916,7 @@ fs-sync@^1.0.4:
     mkdirp "^0.5.1"
     rimraf "^2.1.4"
 
-fs-tree-diff@^0.5.2, fs-tree-diff@^0.5.3, fs-tree-diff@^0.5.4, fs-tree-diff@^0.5.6:
+fs-tree-diff@^0.5.2, fs-tree-diff@^0.5.3, fs-tree-diff@^0.5.4, fs-tree-diff@^0.5.6, fs-tree-diff@^0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz#315e2b098d5fe7f622880ac965b1b051868ac871"
   dependencies:
@@ -3040,13 +2928,6 @@ fs-tree-diff@^0.5.2, fs-tree-diff@^0.5.3, fs-tree-diff@^0.5.4, fs-tree-diff@^0.5
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
-
-fsevents@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.1.1.tgz#f19fd28f43eeaf761680e519a203c4d0b3d31aff"
-  dependencies:
-    nan "^2.3.0"
-    node-pre-gyp "^0.6.29"
 
 fsevents@^1.1.1:
   version "1.1.3"
@@ -3097,10 +2978,6 @@ get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
 
-get-value@^2.0.3, get-value@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
-
 getpass@^0.1.1:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.6.tgz#283ffd9fc1256840875311c1b60e8c40187110e6"
@@ -3110,6 +2987,16 @@ getpass@^0.1.1:
 git-repo-info@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/git-repo-info/-/git-repo-info-1.4.1.tgz#2a072823254aaf62fcf0766007d7b6651bd41943"
+
+glimmer-analyzer@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/glimmer-analyzer/-/glimmer-analyzer-0.3.2.tgz#801f051db5943e529c60cb483c4f78e35623e395"
+  dependencies:
+    "@glimmer/resolution-map-builder" "^0.4.0"
+    "@glimmer/resolver" "^0.3.0"
+    "@glimmer/syntax" "^0.29.1"
+    debug "^3.1.0"
+    simple-html-tokenizer "^0.4.1"
 
 glob-base@^0.3.0:
   version "0.3.0"
@@ -3145,7 +3032,7 @@ glob@^5.0.10:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.4, glob@^7.0.5, glob@^7.1.0, glob@^7.1.1, glob@^7.1.2:
+glob@^7.0.4, glob@^7.0.5, glob@^7.1.0, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -3163,14 +3050,6 @@ global-modules@^0.2.3:
     global-prefix "^0.1.4"
     is-windows "^0.2.0"
 
-global-modules@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-1.0.0.tgz#6d770f0eb523ac78164d72b5e71a8877265cc3ea"
-  dependencies:
-    global-prefix "^1.0.1"
-    is-windows "^1.0.1"
-    resolve-dir "^1.0.0"
-
 global-prefix@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-0.1.5.tgz#8d3bc6b8da3ca8112a160d8d496ff0462bfef78f"
@@ -3179,16 +3058,6 @@ global-prefix@^0.1.4:
     ini "^1.3.4"
     is-windows "^0.2.0"
     which "^1.2.12"
-
-global-prefix@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-1.0.2.tgz#dbf743c6c14992593c655568cb66ed32c0122ebe"
-  dependencies:
-    expand-tilde "^2.0.2"
-    homedir-polyfill "^1.0.1"
-    ini "^1.3.4"
-    is-windows "^1.0.1"
-    which "^1.2.14"
 
 globals@^9.18.0:
   version "9.18.0"
@@ -3281,33 +3150,6 @@ has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
 
-has-value@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/has-value/-/has-value-0.3.1.tgz#7b1f58bada62ca827ec0a2078025654845995e1f"
-  dependencies:
-    get-value "^2.0.3"
-    has-values "^0.1.4"
-    isobject "^2.0.0"
-
-has-value@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-value/-/has-value-1.0.0.tgz#18b281da585b1c5c51def24c930ed29a0be6b177"
-  dependencies:
-    get-value "^2.0.6"
-    has-values "^1.0.0"
-    isobject "^3.0.0"
-
-has-values@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/has-values/-/has-values-0.1.4.tgz#6d61de95d91dfca9b9a02089ad384bff8f62b771"
-
-has-values@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-values/-/has-values-1.0.0.tgz#95b0b63fec2146619a6fe57fe75628d5a39efe4f"
-  dependencies:
-    is-number "^3.0.0"
-    kind-of "^4.0.0"
-
 hash-for-dep@^1.0.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/hash-for-dep/-/hash-for-dep-1.2.3.tgz#5ec69fca32c23523972d52acb5bb65ffc3664cab"
@@ -3367,7 +3209,7 @@ home-or-tmp@^2.0.0:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
 
-homedir-polyfill@^1.0.0, homedir-polyfill@^1.0.1:
+homedir-polyfill@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz#4c2bbc8a758998feebf5ed68580f76d46768b4bc"
   dependencies:
@@ -3489,27 +3331,9 @@ ipaddr.js@1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.5.2.tgz#d4b505bde9946987ccf0fc58d9010ff9607e3fa0"
 
-is-accessor-descriptor@^0.1.6:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
-  dependencies:
-    kind-of "^3.0.2"
-
-is-accessor-descriptor@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz#169c2f6d3df1f992618072365c9b0ea1f6878656"
-  dependencies:
-    kind-of "^6.0.0"
-
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
-
-is-binary-path@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-1.0.1.tgz#75f16642b480f187a711c814161fd3a4a7655898"
-  dependencies:
-    binary-extensions "^1.0.0"
 
 is-buffer@^1.1.5:
   version "1.1.6"
@@ -3521,34 +3345,6 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
-is-data-descriptor@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
-  dependencies:
-    kind-of "^3.0.2"
-
-is-data-descriptor@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#d84876321d0e7add03990406abbbbd36ba9268c7"
-  dependencies:
-    kind-of "^6.0.0"
-
-is-descriptor@^0.1.0:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-0.1.6.tgz#366d8240dde487ca51823b1ab9f07a10a78251ca"
-  dependencies:
-    is-accessor-descriptor "^0.1.6"
-    is-data-descriptor "^0.1.4"
-    kind-of "^5.0.0"
-
-is-descriptor@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-1.0.2.tgz#3b159746a66604b04f8c81524ba365c5f14d86ec"
-  dependencies:
-    is-accessor-descriptor "^1.0.0"
-    is-data-descriptor "^1.0.0"
-    kind-of "^6.0.2"
-
 is-dotfile@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
@@ -3559,23 +3355,13 @@ is-equal-shallow@^0.1.3:
   dependencies:
     is-primitive "^2.0.0"
 
-is-extendable@^0.1.0, is-extendable@^0.1.1:
+is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
-
-is-extendable@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-1.0.1.tgz#a7470f9e426733d81bd81e1155264e3a3507cab4"
-  dependencies:
-    is-plain-object "^2.0.4"
 
 is-extglob@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-1.0.0.tgz#ac468177c4943405a092fc8f29760c6ffc6206c0"
-
-is-extglob@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
 
 is-finite@^1.0.0:
   version "1.0.2"
@@ -3603,11 +3389,9 @@ is-glob@^2.0.0, is-glob@^2.0.1:
   dependencies:
     is-extglob "^1.0.0"
 
-is-glob@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
-  dependencies:
-    is-extglob "^2.1.0"
+is-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
 
 is-number@^2.1.0:
   version "2.1.0"
@@ -3625,21 +3409,9 @@ is-obj@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
 
-is-odd@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-odd/-/is-odd-1.0.0.tgz#3b8a932eb028b3775c39bb09e91767accdb69088"
-  dependencies:
-    is-number "^3.0.0"
-
 is-plain-obj@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
-
-is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
-  dependencies:
-    isobject "^3.0.1"
 
 is-posix-bracket@^0.1.0:
   version "0.1.1"
@@ -3679,10 +3451,6 @@ is-windows@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
 
-is-windows@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.1.tgz#310db70f742d259a16a369202b51af84233310d9"
-
 isarray@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
@@ -3705,10 +3473,6 @@ isobject@^2.0.0:
   dependencies:
     isarray "1.0.0"
 
-isobject@^3.0.0, isobject@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
-
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
@@ -3727,15 +3491,11 @@ jodid25519@^1.0.0:
   dependencies:
     jsbn "~0.1.0"
 
-js-reporters@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/js-reporters/-/js-reporters-1.2.1.tgz#f88c608e324a3373a95bcc45ad305e5c979c459b"
-
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.2.5, js-yaml@^3.2.7, js-yaml@^3.6.1, js-yaml@^3.7.0:
+js-yaml@^3.2.5, js-yaml@^3.2.7, js-yaml@^3.6.1:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
@@ -3801,7 +3561,7 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.3.6"
 
-kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
+kind-of@^3.0.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
   dependencies:
@@ -3813,14 +3573,6 @@ kind-of@^4.0.0:
   dependencies:
     is-buffer "^1.1.5"
 
-kind-of@^5.0.0, kind-of@^5.0.2:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
-
-kind-of@^6.0.0, kind-of@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
-
 klaw@^1.0.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
@@ -3830,12 +3582,6 @@ klaw@^1.0.0:
 lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
-
-lazy-cache@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-2.0.2.tgz#b9190a4f913354694840859f8a8f7084d8822264"
-  dependencies:
-    set-getter "^0.1.0"
 
 leek@0.0.24:
   version "0.0.24"
@@ -3864,10 +3610,6 @@ load-json-file@^1.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
-
-loader.js@^4.0.11:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/loader.js/-/loader.js-4.2.3.tgz#845228877aa5317209e41f6c00d9bab36a6a4808"
 
 locate-path@^2.0.0:
   version "2.0.0"
@@ -4078,19 +3820,9 @@ makeerror@1.0.x:
   dependencies:
     tmpl "1.0.x"
 
-map-cache@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
-
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
-
-map-visit@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
-  dependencies:
-    object-visit "^1.0.0"
 
 markdown-it-terminal@0.1.0:
   version "0.1.0"
@@ -4204,24 +3936,6 @@ micromatch@^2.1.5, micromatch@^2.3.7:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
-micromatch@^3.0.4:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.5.tgz#d05e168c206472dfbca985bfef4f57797b4cd4ba"
-  dependencies:
-    arr-diff "^4.0.0"
-    array-unique "^0.3.2"
-    braces "^2.3.0"
-    define-property "^1.0.0"
-    extend-shallow "^2.0.1"
-    extglob "^2.0.2"
-    fragment-cache "^0.2.1"
-    kind-of "^6.0.0"
-    nanomatch "^1.2.5"
-    object.pick "^1.3.0"
-    regex-not "^1.0.0"
-    snapdragon "^0.8.1"
-    to-regex "^3.0.1"
-
 "mime-db@>= 1.30.0 < 2":
   version "1.32.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.32.0.tgz#485b3848b01a3cda5f968b4882c0771e58e09414"
@@ -4275,13 +3989,6 @@ minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
 minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
-
-mixin-deep@^1.2.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.0.tgz#47a8732ba97799457c8c1eca28f95132d7e8150a"
-  dependencies:
-    for-in "^1.0.2"
-    is-extendable "^1.0.1"
 
 mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
@@ -4347,22 +4054,6 @@ nan@^2.3.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.5.1.tgz#d5b01691253326a97a2bbee9e61c55d8d60351e2"
 
-nanomatch@^1.2.5:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.7.tgz#53cd4aa109ff68b7f869591fdc9d10daeeea3e79"
-  dependencies:
-    arr-diff "^4.0.0"
-    array-unique "^0.3.2"
-    define-property "^1.0.0"
-    extend-shallow "^2.0.1"
-    fragment-cache "^0.2.1"
-    is-odd "^1.0.0"
-    kind-of "^5.0.2"
-    object.pick "^1.3.0"
-    regex-not "^1.0.0"
-    snapdragon "^0.8.1"
-    to-regex "^3.0.1"
-
 negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
@@ -4390,20 +4081,6 @@ node-notifier@^5.0.1:
     semver "^5.4.1"
     shellwords "^0.1.1"
     which "^1.3.0"
-
-node-pre-gyp@^0.6.29:
-  version "0.6.34"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.34.tgz#94ad1c798a11d7fc67381b50d47f8cc18d9799f7"
-  dependencies:
-    mkdirp "^0.5.1"
-    nopt "^4.0.1"
-    npmlog "^4.0.2"
-    rc "^1.1.7"
-    request "^2.81.0"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^2.2.1"
-    tar-pack "^3.4.0"
 
 node-pre-gyp@^0.6.39:
   version "0.6.39"
@@ -4502,32 +4179,12 @@ object-component@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/object-component/-/object-component-0.0.3.tgz#f0c69aa50efc95b866c186f400a33769cb2f1291"
 
-object-copy@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/object-copy/-/object-copy-0.1.0.tgz#7e7d858b781bd7c991a41ba975ed3812754e998c"
-  dependencies:
-    copy-descriptor "^0.1.0"
-    define-property "^0.2.5"
-    kind-of "^3.0.3"
-
-object-visit@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
-  dependencies:
-    isobject "^3.0.0"
-
 object.omit@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/object.omit/-/object.omit-2.0.1.tgz#1a9c744829f39dbb858c76ca3579ae2a54ebd1fa"
   dependencies:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
-
-object.pick@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
-  dependencies:
-    isobject "^3.0.1"
 
 on-finished@~2.3.0:
   version "2.3.0"
@@ -4655,10 +4312,6 @@ parseurl@~1.3.1, parseurl@~1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
 
-pascalcase@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
-
 passwd-user@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/passwd-user/-/passwd-user-1.2.1.tgz#a01a5dc639ef007dc56364b8178569080ad3a7b8"
@@ -4733,10 +4386,6 @@ portfinder@^1.0.7:
     debug "^2.2.0"
     mkdirp "0.5.x"
 
-posix-character-classes@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
-
 preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
@@ -4802,19 +4451,6 @@ quick-temp@^0.1.0, quick-temp@^0.1.2, quick-temp@^0.1.3, quick-temp@^0.1.5, quic
     rimraf "^2.5.4"
     underscore.string "~3.3.4"
 
-qunit@^2.4.1:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/qunit/-/qunit-2.5.0.tgz#64cbe30a1193ef02edc5b278efcdf1d0bae96b22"
-  dependencies:
-    chokidar "1.7.0"
-    commander "2.12.2"
-    exists-stat "1.0.0"
-    findup-sync "2.0.0"
-    js-reporters "1.2.1"
-    resolve "1.5.0"
-    shelljs "^0.2.6"
-    walk-sync "0.3.2"
-
 randomatic@^1.1.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"
@@ -4878,7 +4514,7 @@ readable-stream@^2, readable-stream@^2.0.6, readable-stream@^2.2.2:
     string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
 
-readable-stream@^2.0.2, readable-stream@^2.1.4:
+readable-stream@^2.1.4:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.6.tgz#8b43aed76e71483938d12a8d46c6cf1a00b1f816"
   dependencies:
@@ -4898,15 +4534,6 @@ readable-stream@~1.0.2:
     inherits "~2.0.1"
     isarray "0.0.1"
     string_decoder "~0.10.x"
-
-readdirp@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.1.0.tgz#4ed0ad060df3073300c48440373f72d1cc642d78"
-  dependencies:
-    graceful-fs "^4.1.2"
-    minimatch "^3.0.2"
-    readable-stream "^2.0.2"
-    set-immediate-shim "^1.0.1"
 
 recast@^0.11.3:
   version "0.11.23"
@@ -4952,12 +4579,6 @@ regex-cache@^0.4.2:
   dependencies:
     is-equal-shallow "^0.1.3"
 
-regex-not@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.0.tgz#42f83e39771622df826b02af176525d6a5f157f9"
-  dependencies:
-    extend-shallow "^2.0.1"
-
 regexpu-core@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-2.0.0.tgz#49d038837b8dcf8bfa5b9a42139938e6ea2ae240"
@@ -4984,7 +4605,7 @@ repeat-element@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
 
-repeat-string@^1.5.2, repeat-string@^1.6.1:
+repeat-string@^1.5.2:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
@@ -4994,7 +4615,7 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@2.81.0, request@^2.81.0:
+request@2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -5032,22 +4653,7 @@ resolve-dir@^0.1.0:
     expand-tilde "^1.2.2"
     global-modules "^0.2.3"
 
-resolve-dir@^1.0.0, resolve-dir@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-1.0.1.tgz#79a40644c362be82f26effe739c9bb5382046f43"
-  dependencies:
-    expand-tilde "^2.0.0"
-    global-modules "^1.0.0"
-
-resolve-url@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
-
-resolve@1.1.7:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
-
-resolve@1.5.0, resolve@^1.1.6, resolve@^1.3.0, resolve@^1.3.3, resolve@^1.4.0:
+resolve@^1.1.6, resolve@^1.3.0, resolve@^1.3.3, resolve@^1.4.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
   dependencies:
@@ -5058,10 +4664,6 @@ resolve@^1.3.2:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.2.tgz#1f0442c9e0cbb8136e87b9305f932f46c7f28235"
   dependencies:
     path-parse "^1.0.5"
-
-resolve@~0.6.1:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-0.6.3.tgz#dd957982e7e736debdf53b58a4dd91754575dd46"
 
 restore-cursor@^1.0.1:
   version "1.0.1"
@@ -5108,12 +4710,12 @@ rollup-plugin-babel@^2.7.1:
     object-assign "^4.1.0"
     rollup-pluginutils "^1.5.0"
 
-rollup-plugin-node-resolve@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-2.1.1.tgz#cbb783b0d15b02794d58915350b2f0d902b8ddc8"
+rollup-plugin-node-resolve@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.0.2.tgz#38babc12fd404cc2ba1ff68648fe43fa3ffee6b0"
   dependencies:
-    browser-resolve "^1.11.0"
     builtin-modules "^1.1.0"
+    is-module "^1.0.0"
     resolve "^1.1.6"
 
 rollup-pluginutils@^1.5.0:
@@ -5244,34 +4846,6 @@ set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
 
-set-getter@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/set-getter/-/set-getter-0.1.0.tgz#d769c182c9d5a51f409145f2fba82e5e86e80376"
-  dependencies:
-    to-object-path "^0.3.0"
-
-set-immediate-shim@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
-
-set-value@^0.4.3:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/set-value/-/set-value-0.4.3.tgz#7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1"
-  dependencies:
-    extend-shallow "^2.0.1"
-    is-extendable "^0.1.1"
-    is-plain-object "^2.0.1"
-    to-object-path "^0.3.0"
-
-set-value@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.0.tgz#71ae4a88f0feefbbf52d1ea604f3fb315ebb6274"
-  dependencies:
-    extend-shallow "^2.0.1"
-    is-extendable "^0.1.1"
-    is-plain-object "^2.0.3"
-    split-string "^3.0.1"
-
 setprototypeof@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.3.tgz#66567e37043eeb4f04d91bd658c0cbefb55b8e04"
@@ -5290,10 +4864,6 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-shelljs@^0.2.6:
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.2.6.tgz#90492d72ffcc8159976baba62fb0f6884f0c3378"
-
 shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
@@ -5308,6 +4878,16 @@ silent-error@^1.0.0, silent-error@^1.0.1, silent-error@^1.1.0:
   dependencies:
     debug "^2.2.0"
 
+simple-dom@^1.4.0-alpha.82914663:
+  version "1.4.0-alpha.82914663"
+  resolved "https://registry.yarnpkg.com/simple-dom/-/simple-dom-1.4.0-alpha.82914663.tgz#fda73c0522a81a9526677508b04ebfbe81fb571d"
+  dependencies:
+    "@simple-dom/document" "^1.4.0-alpha.82914663"
+    "@simple-dom/interface" "^1.4.0-alpha.82914663"
+    "@simple-dom/parser" "^1.4.0-alpha.82914663"
+    "@simple-dom/serializer" "^1.4.0-alpha.82914663"
+    "@simple-dom/void-map" "^1.4.0-alpha.82914663"
+
 simple-html-tokenizer@^0.4.1:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.4.3.tgz#9b00b766e30058b4bb377c0d4f97566a13ab1be1"
@@ -5315,33 +4895,6 @@ simple-html-tokenizer@^0.4.1:
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
-
-snapdragon-node@^2.0.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
-  dependencies:
-    define-property "^1.0.0"
-    isobject "^3.0.0"
-    snapdragon-util "^3.0.1"
-
-snapdragon-util@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/snapdragon-util/-/snapdragon-util-3.0.1.tgz#f956479486f2acd79700693f6f7b805e45ab56e2"
-  dependencies:
-    kind-of "^3.2.0"
-
-snapdragon@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/snapdragon/-/snapdragon-0.8.1.tgz#e12b5487faded3e3dea0ac91e9400bf75b401370"
-  dependencies:
-    base "^0.11.1"
-    debug "^2.2.0"
-    define-property "^0.2.5"
-    extend-shallow "^2.0.1"
-    map-cache "^0.2.2"
-    source-map "^0.5.6"
-    source-map-resolve "^0.5.0"
-    use "^2.0.0"
 
 sntp@1.x.x:
   version "1.0.9"
@@ -5403,16 +4956,6 @@ sort-package-json@^1.4.0:
   dependencies:
     sort-object-keys "^1.1.1"
 
-source-map-resolve@^0.5.0:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.1.tgz#7ad0f593f2281598e854df80f19aae4b92d7a11a"
-  dependencies:
-    atob "^2.0.0"
-    decode-uri-component "^0.2.0"
-    resolve-url "^0.2.1"
-    source-map-url "^0.4.0"
-    urix "^0.1.0"
-
 source-map-support@^0.4.0:
   version "0.4.14"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.14.tgz#9d4463772598b86271b4f523f6c1f4e02a7d6aef"
@@ -5428,10 +4971,6 @@ source-map-support@^0.4.15:
 source-map-url@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.3.0.tgz#7ecaf13b57bcd09da8a40c5d269db33799d4aaf9"
-
-source-map-url@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
 
 source-map@0.4.x, source-map@^0.4.2, source-map@^0.4.4:
   version "0.4.4"
@@ -5468,12 +5007,6 @@ spdx-license-ids@^1.0.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
 
-split-string@^3.0.1, split-string@^3.0.2:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
-  dependencies:
-    extend-shallow "^3.0.0"
-
 sprintf-js@^1.0.3:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.1.tgz#36be78320afe5801f6cea3ee78b6e5aab940ea0c"
@@ -5496,17 +5029,6 @@ sshpk@^1.7.0:
     jodid25519 "^1.0.0"
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
-
-stack-trace@^0.0.9:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.9.tgz#a8f6eaeca90674c333e7c43953f275b451510695"
-
-static-extend@^0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
-  dependencies:
-    define-property "^0.2.5"
-    object-copy "^0.1.0"
 
 "statuses@>= 1.3.1 < 2":
   version "1.4.0"
@@ -5674,36 +5196,6 @@ testdouble@^2.1.2:
     resolve "^1.3.2"
     stringify-object-es5 "^2.5.0"
 
-testem@^1.13.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/testem/-/testem-1.15.0.tgz#2e3a9e7ac29f16a20f718eb0c4b12e7a44900675"
-  dependencies:
-    backbone "^1.1.2"
-    bluebird "^3.4.6"
-    charm "^1.0.0"
-    commander "^2.6.0"
-    consolidate "^0.14.0"
-    cross-spawn "^5.0.0"
-    express "^4.10.7"
-    fireworm "^0.7.0"
-    glob "^7.0.4"
-    http-proxy "^1.13.1"
-    js-yaml "^3.2.5"
-    lodash.assignin "^4.1.0"
-    lodash.clonedeep "^4.4.1"
-    lodash.find "^4.5.1"
-    mkdirp "^0.5.1"
-    mustache "^2.2.1"
-    node-notifier "^5.0.1"
-    npmlog "^4.0.0"
-    printf "^0.2.3"
-    rimraf "^2.4.4"
-    socket.io "1.6.0"
-    spawn-args "^0.2.0"
-    styled_string "0.0.1"
-    tap-parser "^5.1.0"
-    xmldom "^0.1.19"
-
 testem@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/testem/-/testem-2.0.0.tgz#b05c96200c7ac98bae998d71c94c0c5345907d13"
@@ -5786,27 +5278,6 @@ to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 
-to-object-path@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af"
-  dependencies:
-    kind-of "^3.0.2"
-
-to-regex-range@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-2.1.1.tgz#7c80c17b9dfebe599e27367e0d4dd5590141db38"
-  dependencies:
-    is-number "^3.0.0"
-    repeat-string "^1.6.1"
-
-to-regex@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/to-regex/-/to-regex-3.0.1.tgz#15358bee4a2c83bd76377ba1dc049d0f18837aae"
-  dependencies:
-    define-property "^0.2.5"
-    extend-shallow "^2.0.1"
-    regex-not "^1.0.0"
-
 tough-cookie@~2.3.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
@@ -5830,33 +5301,6 @@ trim-newlines@^1.0.0:
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
-
-tslib@^1.8.0, tslib@^1.8.1:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
-
-tslint@^5.9.1:
-  version "5.9.1"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.9.1.tgz#1255f87a3ff57eb0b0e1f0e610a8b4748046c9ae"
-  dependencies:
-    babel-code-frame "^6.22.0"
-    builtin-modules "^1.1.1"
-    chalk "^2.3.0"
-    commander "^2.12.1"
-    diff "^3.2.0"
-    glob "^7.1.1"
-    js-yaml "^3.7.0"
-    minimatch "^3.0.4"
-    resolve "^1.3.2"
-    semver "^5.3.0"
-    tslib "^1.8.0"
-    tsutils "^2.12.1"
-
-tsutils@^2.12.1:
-  version "2.21.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.21.0.tgz#43466a2283a0abce64e2209bc732ad72f8a04fab"
-  dependencies:
-    tslib "^1.8.1"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -5887,9 +5331,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@~2.6.0, typescript@~2.6.1:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
+typescript@~2.7.0, typescript@~2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.1.tgz#bb3682c2c791ac90e7c6210b26478a8da085c359"
 
 uc.micro@^1.0.1, uc.micro@^1.0.3:
   version "1.0.5"
@@ -5927,15 +5371,6 @@ underscore@>=1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
 
-union-value@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
-  dependencies:
-    arr-union "^3.1.0"
-    get-value "^2.0.6"
-    is-extendable "^0.1.1"
-    set-value "^0.4.3"
-
 unique-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a"
@@ -5950,30 +5385,11 @@ unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
 
-unset-value@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/unset-value/-/unset-value-1.0.0.tgz#8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559"
-  dependencies:
-    has-value "^0.3.1"
-    isobject "^3.0.0"
-
 untildify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/untildify/-/untildify-2.1.0.tgz#17eb2807987f76952e9c0485fc311d06a826a2e0"
   dependencies:
     os-homedir "^1.0.0"
-
-urix@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
-
-use@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/use/-/use-2.0.2.tgz#ae28a0d72f93bf22422a18a2e379993112dec8e8"
-  dependencies:
-    define-property "^0.2.5"
-    isobject "^3.0.0"
-    lazy-cache "^2.0.2"
 
 user-info@^1.0.0:
   version "1.0.0"
@@ -6032,16 +5448,16 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-walk-sync@0.3.2, walk-sync@^0.3.0, walk-sync@^0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.3.2.tgz#4827280afc42d0e035367c4a4e31eeac0d136f75"
+walk-sync@^0.2.5, walk-sync@^0.2.7:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.2.7.tgz#b49be4ee6867657aeb736978b56a29d10fa39969"
   dependencies:
     ensure-posix-path "^1.0.0"
     matcher-collection "^1.0.0"
 
-walk-sync@^0.2.5, walk-sync@^0.2.7:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.2.7.tgz#b49be4ee6867657aeb736978b56a29d10fa39969"
+walk-sync@^0.3.0, walk-sync@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.3.2.tgz#4827280afc42d0e035367c4a4e31eeac0d136f75"
   dependencies:
     ensure-posix-path "^1.0.0"
     matcher-collection "^1.0.0"
@@ -6081,7 +5497,7 @@ websocket-extensions@>=0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
 
-which@^1.2.12, which@^1.2.14, which@^1.2.9, which@^1.3.0:
+which@^1.2.12, which@^1.2.9, which@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:


### PR DESCRIPTION
This PR adds support for compiling templates in Glimmer.js apps as Glimmer bytecode, rather than the precompiled JSON format. Apps using bytecode templates not only perform much less work on initial boot, they can ship much less code to the browser, too.

## New Public API

This PR adds a new, optional configuration flag to the `GlimmerApp` constructor that opts into bytecode compilation. An `ember-cli-build.js` file with bytecode enabled would look like this:

```js
const GlimmerApp = require('@glimmer/application-pipeline').GlimmerApp;

module.exports = function(defaults) {
  let app = new GlimmerApp(defaults, {
    templateFormat: 'bytecode'
  });

  return app.toTree();
};
```

Users can either *not* pass the `templateFormat` configuration, or set it to `"json"`, to retain the current, precompiled-as-JSON behavior.

With bytecode compilation enabled, we produce two new artifacts:

1. The bytecode itself, which is saved in a file called `templates.gbx`.
2. The data segment, a JavaScript module which contains metadata needed to evaluate the bytecode in the browser. This includes things like the external module table which translates bytecode handles (integer IDs) into things like component JavaScript classes at runtime. This module is saved in a file at `src/data-segment.js`.

Once enabled, bytecode can be consumed like this (`src/main.ts`):

```ts
import Application, { BytecodeLoader, DOMBuilder, AsyncRenderer } from '@glimmer/application';
import Resolver, { BasicModuleRegistry } from '@glimmer/resolver';
import resolverConfiguration from '../config/resolver-configuration';

// Import the generated data segment module
import data from './data-segment';

export default class App extends Application {
  constructor() {
    const moduleRegistry = new BasicModuleRegistry(data.meta);
    const resolver = new Resolver(resolverConfiguration, moduleRegistry);
    const element = document.body;

    // Fetch the bytecode binary file. Probably want to use H2 Push or
    // <link rel="preload">!
    const bytecode = fetch('./templates.gbx', { credentials: 'include' })
      .then((r) => r.arrayBuffer());

    super({
      builder: new DOMBuilder({ element, nextSibling: null }),
      loader: new BytecodeLoader({ bytecode, data }),
      renderer: new AsyncRenderer(),
      resolver,
      rootName: resolverConfiguration.app.rootName
    });
  }
}
```

## End to End Smoke Test

This PR adds an end-to-end smoke test for a compiled application with bytecode templates similar to the one @chadhietala added to Glimmer.js. It uses the application pipeline to compile a real app and its dependencies into an output file, then renders it in Node using Glimmer's SSR functionality. This gives us a higher degree of confidence that the output of the build pipeline is actually functional.

I also have some confidence that this works in real apps because I was able to get both the Glimmer.js Playground and [a small API viewer app](https://github.com/tomdale/ketab) booting with bytecode templates. (Although note we will require a new release of Glimmer.js containing https://github.com/glimmerjs/glimmer.js/pull/113).

## `GlimmerApp` Cleanup

I tried to clean up the implementation of `GlimmerApp` where appropriate and better align the `package()` hook with the proposal for Ember CLI.

Regarding the `package()` hook, the biggest change is that it now receives a single tree of "loose modules" and other files, rather than independent trees of HTML, CSS, JavaScript and the `public` directory. I needed to implement this change in this PR because the bytecode template compiler is more akin to a packaging step than a transpiler. I needed access to the raw `.hbs` files to produce the `.gbx` file, but those `.hbs` files were being transformed into `.ts` files very early in the compilation pipeline.

The semantics as implemented here are as follows:

1. Anything that will ultimately be represented as JavaScript in the browser should be transformed into "loose modules" of ES2017 JavaScript in the `javascriptTree()` hook. For example, TypeScript should  be transpiled into JavaScript, and in non-bytecode mode, Handlebars templates should be transformed into JSON-as-JS-modules here.
2. The `package()` hooks receives a tree of assets that have been normalized into high fidelity JavaScript, CSS and HTML. When I say "high fidelity" I mean that they should not have had any processing applied other than turning them into the most recent syntax, e.g. received JavaScript should be ES2017 and module syntax. The `package()` hook should return a tree of assets appropriate for serving to the browser.

I also tried to perform some other cleanup as I was working:

1. Similar hooks should reflect that symmetry in their naming. E.g. we had `hbsTree()`, `cssTree()` and `htmlTree()` but the equivalent method for JavaScript was called `javascript()`. I renamed this to `javascriptTree()`.
2. When in doubt, I made hooks like these `protected` rather than `private`. The protocol seemed pretty well-defined to me and we should allow experimentation via subclassing, which `private` methods make much more difficult.
3. I made some small tweaks here and there to the `GlimmerApp` tests to cause them to emit fewer warnings, making the output less noisy and making real errors or warnings more obvious.

## Upgraded, Simplified TypeScript

Prior to this PR, we had a dependency on `@glimmer/build` for a single helper function for compiling TypeScript trees. All of the functionality in that helper method (ensuring the TypeScript compiler could find node_modules and lib files) is now handled in `broccoli-typescript-compiler` automatically. I dropped the `@glimmer/build` dependency and just use `broccoli-typescript-compiler` directly now.

In addition to being simpler, I needed to do this because `@glimmer/build` included `@types/qunit` as a dependency which was causing type errors due to a conflict with our `@types/mocha` dependency.

The version of TypeScript used by this repository itself was also upgraded to TypeScript 2.7 and uses the latest `typescript-broccoli-compiler` (thanks to @krisselden for his help fixing a few bugs there and cutting a new release).

## Drop Support for Node <8

This PR drops Node 4 and 6 from our Travis config, aligning with the support matrix in glimmerjs/glimmer.js. Without this change, trying to run `@glimmer/app-compiler` in Node 6 and below fails with a syntax error due to the use of async functions.

## Open Questions

1. Is the public API acceptable?
  1. Is `templateFormat` the right name? Is it more of a mode than a format? What will be most clear to uses?
  2. Are the default output paths for assets okay? Should we make it more obvious that they are generated during the build, like `import dataSegment from '../__COMPILED__/data` or something?