### PR TITLE
feat: Pass glimmer-ast-plugins discovered in the registry to the Glimmer compilers.

### DIFF
--- a/lib/broccoli/compilers/glimmer-json-compiler.ts
+++ b/lib/broccoli/compilers/glimmer-json-compiler.ts
@@ -1,4 +1,4 @@
-import { GlimmerTemplatePrecompiler, } from 'ember-build-utilities';
+import { GlimmerTemplatePrecompiler, GlimmerTemplatePrecompilerOptions } from 'ember-build-utilities';
 import { Tree } from 'broccoli';
 
 /**
@@ -8,7 +8,7 @@ import { Tree } from 'broccoli';
 export default class GlimmerJSONCompiler extends GlimmerTemplatePrecompiler {
   targetExtension: string;
 
-  constructor(inputNode: Tree, options: any) {
+  constructor(inputNode: Tree, options: GlimmerTemplatePrecompilerOptions) {
     super(inputNode, options);
     this.targetExtension = 'js';
   }

--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -13,6 +13,7 @@ import ConfigReplace = require("broccoli-config-replace");
 import ResolutionMapBuilder = require("@glimmer/resolution-map-builder");
 import ResolverConfigurationBuilder = require("@glimmer/resolver-configuration-builder");
 import { GlimmerBundleCompiler } from "@glimmer/app-compiler";
+import { ASTPluginBuilder } from "@glimmer/syntax";
 
 import {
   Project,
@@ -234,9 +235,13 @@ export default class GlimmerApp extends AbstractBuild {
    */
   protected compileTemplatesToJSON(appTree: Tree): Tree {
     let glimmerEnv = this.getGlimmerEnvironment();
+    let astPlugins = this.registry.load('glimmer-ast-plugin') as ASTPluginBuilder[];
     return new GlimmerJSONCompiler(appTree, {
       rootName: this.project.pkg.name,
-      GlimmerENV: glimmerEnv
+      GlimmerENV: glimmerEnv,
+      plugins: {
+        ast: astPlugins
+      }
     });
   }
 
@@ -250,12 +255,16 @@ export default class GlimmerApp extends AbstractBuild {
     });
 
     let templateTree: Tree = new MergeTrees([appTree, pkgJsonTree]);
+    let astPlugins = this.registry.load('glimmer-ast-plugin') as ASTPluginBuilder[];
 
     let compiledOutput = new GlimmerBundleCompiler(templateTree, {
       mode: 'module-unification',
       outputFiles: {
         heapFile: 'templates.gbx',
         dataSegment: 'src/data-segment.js'
+      },
+      bundleCompiler: {
+        plugins: astPlugins
       }
     });
 

--- a/lib/typings.d.ts
+++ b/lib/typings.d.ts
@@ -202,6 +202,7 @@ declare module "ember-cli-preprocess-registry/preprocessors" {
 
   export interface Registry {
     add(type: string, plugin: Function): void;
+    load(type: string): Function[];
   }
 
   export function setupRegistry(app: AbstractBuild): void;
@@ -225,12 +226,13 @@ declare module "ember-cli-blueprint-test-helpers/helpers" {
 
 declare module "ember-build-utilities" {
   import { Tree } from "broccoli";
-
+  import { ASTPluginBuilder } from "@glimmer/syntax"
   export function addonProcessTree(project: Project, hook: string, target: string, tree: Tree): Tree;
 
   interface GlimmerTemplatePrecompilerOptions {
     rootName: string;
     GlimmerENV: string;
+    plugins: { ast: ASTPluginBuilder[] }
   }
 
   export class GlimmerTemplatePrecompiler {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ember-build-utilities": "^0.4.0",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-normalize-entity-name": "^1.0.0",
-    "ember-cli-preprocess-registry": "^3.1.1",
+    "ember-cli-preprocess-registry": "ember-cli/ember-cli-preprocessor-registry",
     "ember-cli-string-utils": "^1.1.0",
     "exists-sync": "^0.0.4",
     "glob": "^7.1.2",

--- a/tests/broccoli/bytecode-templates-test.ts
+++ b/tests/broccoli/bytecode-templates-test.ts
@@ -1,3 +1,5 @@
+import { AST, ASTPlugin } from "@glimmer/syntax";
+
 import GlimmerApp from '../../lib/broccoli/glimmer-app';
 import { GlimmerAppOptions } from '../../lib/interfaces';
 import { buildOutput, createTempDir, TempDir } from 'broccoli-test-helper';
@@ -5,10 +7,14 @@ import path = require('path');
 import { readFileSync } from 'fs';
 import * as SimpleDOM from 'simple-dom';
 
-const expect = require('../helpers/chai').expect;
+const { expect } = require('../helpers/chai');
 const MockCLI = require('ember-cli/tests/helpers/mock-cli');
 const Project = require('ember-cli/lib/models/project');
 const { stripIndent } = require('common-tags');
+
+class TestGlimmerApp extends GlimmerApp {
+  public getRegistry() { return this.registry; }
+}
 
 describe('Bytecode Template Compilation', function() {
   this.timeout(20000);
@@ -23,13 +29,13 @@ describe('Bytecode Template Compilation', function() {
     return createTempDir().then(tempDir => (input = tempDir));
   });
 
-  function createApp(options: GlimmerAppOptions = {}, addons: any[] = []): GlimmerApp {
+  function createApp(options: GlimmerAppOptions = {}, addons: any[] = []): TestGlimmerApp {
     let cli = new MockCLI();
     let project = new Project(input.path(), pkg, cli.ui, cli);
     project.initializeAddons();
     project.addons = project.addons.concat(addons);
 
-    return new GlimmerApp({
+    return new TestGlimmerApp({
       project
     }, options);
   }
@@ -126,6 +132,64 @@ describe('Bytecode Template Compilation', function() {
     let serializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
     let html = serializer.serializeChildren(doc.body as any).trim();
     expect(html).to.equal('<div>Hello!</div><!---->');
+  });
+
+  it('applies `glimmer-ast-plugin`s discovered in the app registry', async function () {
+    input.write({
+      'package.json': JSON.stringify(pkg),
+      'config': {
+        'resolver-configuration.d.ts': `declare var _default: any; export default _default;`
+      },
+      'src': {
+        'index.ts': indexTsContents,
+        'data-segment.d.ts': `declare var _default: any; export default _default;`,
+        'ui': {
+          'index.html': 'src',
+          'components': {
+            'App': {
+              'template.hbs': `<div>Hello!</div>`,
+              'component.ts': `import Component from "@glimmer/component"; export default class extends Component { };`
+            }
+          }
+        }
+      },
+      'tsconfig.json': tsconfigContents
+    });
+
+    let app = createApp({
+      templateFormat: 'bytecode',
+      trees: {
+        nodeModules: path.join(__dirname, '..', '..', '..', 'node_modules')
+      }
+    });
+
+    app.getRegistry().add('glimmer-ast-plugin', function(): ASTPlugin{
+      return {
+        name: 'test-plugin',
+        visitor: {
+          ElementNode(node: AST.ElementNode) {
+            node.tag = 'span';
+          }
+        }
+      }
+    });
+
+    let output = await buildOutput(app.toTree());
+    let actual = output.read();
+
+    let bytecode = readFileAsArrayBuffer(output.path('templates.gbx'));
+    let buildApp = evalModule(actual['app.js'] as string);
+
+    let doc = new SimpleDOM.Document();
+    let glimmerApp = buildApp(bytecode, doc);
+
+    glimmerApp.renderComponent('App', doc.body, null);
+    await glimmerApp.boot();
+
+    let serializer = new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap);
+    let html = serializer.serializeChildren(doc.body as any).trim();
+    expect(html).to.equal('<span>Hello!</span><!---->');
+
   });
 });
 

--- a/tests/broccoli/glimmer-app-test.ts
+++ b/tests/broccoli/glimmer-app-test.ts
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('path');
+import { AST, ASTPlugin } from "@glimmer/syntax";
 
 import { buildOutput, createTempDir, TempDir } from 'broccoli-test-helper';
 
@@ -875,5 +876,50 @@ describe('glimmer-app', function() {
         expect(app.getGlimmerEnvironment()).to.deep.equal({ FEATURES: {} });
       });
     });
+
+    // describe('glimer-ast-plugin', () => {
+    //   it('applies `glimmer-ast-plugin`s discovered in the app registry', () => {
+    //     input.write({
+    //       'package.json': JSON.stringify(pkg),
+    //       'config': {
+    //         'resolver-configuration.d.ts': `declare var _default: any; export default _default;`
+    //       },
+    //       'src': {
+    //         'index.ts': indexTsContents,
+    //         'data-segment.d.ts': `declare var _default: any; export default _default;`,
+    //         'ui': {
+    //           'index.html': 'src',
+    //           'components': {
+    //             'App': {
+    //               'template.hbs': `<div>Hello!</div>`,
+    //               'component.ts': `import Component from "@glimmer/component"; export default class extends Component { };`
+    //             }
+    //           }
+    //         }
+    //       },
+    //       'tsconfig.json': tsconfigContents
+    //     });
+
+    //     let app = createApp({
+    //       trees: {
+    //         nodeModules: path.join(__dirname, '..', '..', '..', 'node_modules')
+    //       }
+    //     });
+
+    //     app.getRegistry().add('glimmer-ast-plugin', function (): ASTPlugin {
+    //       return {
+    //         name: 'test-plugin',
+    //         visitor: {
+    //           ElementNode(node: AST.ElementNode) {
+    //             node.tag = 'span';
+    //           }
+    //         }
+    //       }
+    //     });
+    //
+    //     TODO: Add assertions here.
+    //   });
+    // });
+
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -447,16 +447,6 @@ array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
 
-array-to-error@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/array-to-error/-/array-to-error-1.1.1.tgz#d68812926d14097a205579a667eeaf1856a44c07"
-  dependencies:
-    array-to-sentence "^1.1.0"
-
-array-to-sentence@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/array-to-sentence/-/array-to-sentence-1.1.0.tgz#c804956dafa53232495b205a9452753a258d39fc"
-
 array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
@@ -1200,15 +1190,6 @@ broccoli-caching-writer@^3.0.3:
     rsvp "^3.0.17"
     walk-sync "^0.3.0"
 
-broccoli-clean-css@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/broccoli-clean-css/-/broccoli-clean-css-1.1.0.tgz#9db143d9af7e0ae79c26e3ac5a9bb2d720ea19fa"
-  dependencies:
-    broccoli-persistent-filter "^1.1.6"
-    clean-css-promise "^0.1.0"
-    inline-source-map-comment "^1.0.5"
-    json-stable-stringify "^1.0.0"
-
 broccoli-concat@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/broccoli-concat/-/broccoli-concat-3.2.2.tgz#86ffdc52606eb590ba9f6b894c5ec7a016f5b7b9"
@@ -1708,21 +1689,6 @@ clean-base-url@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/clean-base-url/-/clean-base-url-1.0.0.tgz#c901cf0a20b972435b0eccd52d056824a4351b7b"
 
-clean-css-promise@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/clean-css-promise/-/clean-css-promise-0.1.1.tgz#43f3d2c8dfcb2bf071481252cd9b76433c08eecb"
-  dependencies:
-    array-to-error "^1.0.0"
-    clean-css "^3.4.5"
-    pinkie-promise "^2.0.0"
-
-clean-css@^3.4.5:
-  version "3.4.28"
-  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-3.4.28.tgz#bf1945e82fc808f55695e6ddeaec01400efd03ff"
-  dependencies:
-    commander "2.8.x"
-    source-map "0.4.x"
-
 cli-cursor@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
@@ -1805,12 +1771,6 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
   dependencies:
     delayed-stream "~1.0.0"
-
-commander@2.8.x:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.8.1.tgz#06be367febfda0c330aa1e2a072d3dc9762425d4"
-  dependencies:
-    graceful-readlink ">= 1.0.0"
 
 commander@2.9.0, commander@^2.5.0:
   version "2.9.0"
@@ -2218,10 +2178,6 @@ ember-cli-legacy-blueprints@^0.2.0:
     rsvp "^4.7.0"
     silent-error "^1.0.0"
 
-ember-cli-lodash-subset@^1.0.7:
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/ember-cli-lodash-subset/-/ember-cli-lodash-subset-1.0.12.tgz#af2e77eba5dcb0d77f3308d3a6fd7d3450f6e537"
-
 ember-cli-lodash-subset@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ember-cli-lodash-subset/-/ember-cli-lodash-subset-2.0.1.tgz#20cb68a790fe0fde2488ddfd8efbb7df6fe766f2"
@@ -2236,17 +2192,13 @@ ember-cli-path-utils@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-path-utils/-/ember-cli-path-utils-1.0.0.tgz#4e39af8b55301cddc5017739b77a804fba2071ed"
 
-ember-cli-preprocess-registry@^3.1.0, ember-cli-preprocess-registry@^3.1.1:
+ember-cli-preprocess-registry@^3.1.0, ember-cli-preprocess-registry@ember-cli/ember-cli-preprocessor-registry:
   version "3.1.1"
-  resolved "https://registry.yarnpkg.com/ember-cli-preprocess-registry/-/ember-cli-preprocess-registry-3.1.1.tgz#38456c21c4d2b64945850cf9ec68db6ba769288a"
+  resolved "https://codeload.github.com/ember-cli/ember-cli-preprocessor-registry/tar.gz/3b94744c30d6c7dfe2ed74d71209ca589bfaef19"
   dependencies:
-    broccoli-clean-css "^1.1.0"
     broccoli-funnel "^1.0.0"
     broccoli-merge-trees "^1.0.0"
     debug "^2.2.0"
-    ember-cli-lodash-subset "^1.0.7"
-    exists-sync "0.0.3"
-    process-relative-require "^1.0.0"
     silent-error "^1.0.0"
 
 ember-cli-string-utils@^1.0.0, ember-cli-string-utils@^1.1.0:
@@ -3291,16 +3243,6 @@ ini@^1.3.4:
 ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
-
-inline-source-map-comment@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/inline-source-map-comment/-/inline-source-map-comment-1.0.5.tgz#50a8a44c2a790dfac441b5c94eccd5462635faf6"
-  dependencies:
-    chalk "^1.0.0"
-    get-stdin "^4.0.1"
-    minimist "^1.1.1"
-    sum-up "^1.0.1"
-    xtend "^4.0.0"
 
 inquirer@^2:
   version "2.0.0"
@@ -4402,12 +4344,6 @@ process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
-process-relative-require@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/process-relative-require/-/process-relative-require-1.0.0.tgz#1590dfcf5b8f2983ba53e398446b68240b4cc68a"
-  dependencies:
-    node-modules-path "^1.0.0"
-
 promise-map-series@^0.2.1:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/promise-map-series/-/promise-map-series-0.2.3.tgz#c2d377afc93253f6bd03dbb77755eb88ab20a847"
@@ -4972,7 +4908,7 @@ source-map-url@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.3.0.tgz#7ecaf13b57bcd09da8a40c5d269db33799d4aaf9"
 
-source-map@0.4.x, source-map@^0.4.2, source-map@^0.4.4:
+source-map@^0.4.2, source-map@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
   dependencies:
@@ -5119,12 +5055,6 @@ strip-json-comments@~2.0.1:
 styled_string@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/styled_string/-/styled_string-0.0.1.tgz#d22782bd81295459bc4f1df18c4bad8e94dd124a"
-
-sum-up@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/sum-up/-/sum-up-1.0.3.tgz#1c661f667057f63bcb7875aa1438bc162525156e"
-  dependencies:
-    chalk "^1.0.0"
 
 supports-color@3.1.2:
   version "3.1.2"
@@ -5556,7 +5486,7 @@ xmlhttprequest-ssl@1.5.3:
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz#185a888c04eca46c3e4070d99f7b49de3528992d"
 
-xtend@^4.0.0, xtend@~4.0.0:
+xtend@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 


### PR DESCRIPTION
~~Still need a passing test for the JSON compiler. Bytecode compiler is tested.~~

This change requires a `3.2.0` release of `ember-cli-preprocessor-registry` that includes [Robert Jackson's updates to `registry.add`](https://github.com/ember-cli/ember-cli-preprocessor-registry/commit/22379e12919520a86101f0f8ef314b7de43e4352#diff-168726dbe96b3ce427e7fedce31bb0bcL60) so we can actually register the new `ASTPluginBuilder` type in the app registry.