### PR TITLE
[ Fix #146 ] move addonProcessTree to the correct position 

### DIFF
--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -67,6 +67,8 @@ class MissingProjectError extends Error {
   message = "You must pass through the default arguments passed into your ember-cli-build.js file when constructing a new GlimmerApp";
 }
 
+type GlimmerPossibleEnvironments = "production" | "development" | "test";
+
 /**
  * GlimmerApp provides an interface to a package (app, engine, or addon)
  * compatible with the module unification layout.
@@ -79,7 +81,7 @@ class MissingProjectError extends Error {
 export default class GlimmerApp extends AbstractBuild {
   public project!: Project;
   public name: string;
-  public env: "production" | "development" | "test";
+  public env: GlimmerPossibleEnvironments;
   protected options!: GlimmerAppOptions;
   protected trees: Trees;
   protected registry: Registry;
@@ -91,7 +93,7 @@ export default class GlimmerApp extends AbstractBuild {
       throw new MissingProjectError();
     }
 
-    let env = process.env.EMBER_ENV || "development";
+    let env = (process.env.EMBER_ENV as GlimmerPossibleEnvironments) || "development";
     let isProduction = env === "production";
     let defaults = getDefaultOptions(upstreamDefaults, isProduction);
 

--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -67,7 +67,7 @@ class MissingProjectError extends Error {
   message = "You must pass through the default arguments passed into your ember-cli-build.js file when constructing a new GlimmerApp";
 }
 
-type GlimmerPossibleEnvironments = "production" | "development" | "test";
+export type GlimmerPossibleEnvironments = "production" | "development" | "test";
 
 /**
  * GlimmerApp provides an interface to a package (app, engine, or addon)

--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -143,11 +143,8 @@ export default class GlimmerApp extends AbstractBuild {
     });
 
     let trees = [appTree, jsTree, ...otherTrees];
-    appTree = new MergeTrees(trees);
+    return new MergeTrees(trees);
 
-    appTree = addonProcessTree(this.project, "postprocessTree", "all", appTree);
-
-    return appTree;
   }
 
   /**
@@ -167,7 +164,8 @@ export default class GlimmerApp extends AbstractBuild {
 
     let appTree = new MergeTrees(trees);
 
-    return new MergeTrees([this.publicTree(), this.package(appTree)]);
+    let packagedTree = new MergeTrees([this.publicTree(), this.package(appTree)]);
+    return addonProcessTree(this.project, "postprocessTree", "all", packagedTree);
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@types/babel-types": "^7.0.0",
     "@types/chai": "^4.1.2",
     "@types/chai-as-promised": "^7.1.0",
+    "@types/chokidar": "^1.7.5",
     "@types/lodash.defaultsdeep": "^4.6.3",
     "@types/mocha": "^2.2.41",
     "@types/node": "^7.0.18",
@@ -82,6 +83,7 @@
     "ember-cli-blueprint-test-helpers": "^0.17.2",
     "mocha": "^3.4.1",
     "simple-dom": "^1.4.0-alpha.82914663",
+    "source-map": "^0.7.3",
     "testdouble": "^2.1.2",
     "typescript": "~3.1.4"
   },

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "mocha": "^3.4.1",
     "simple-dom": "^1.4.0-alpha.82914663",
     "testdouble": "^2.1.2",
-    "typescript": "~2.7.0"
+    "typescript": "~3.1.4"
   },
   "ember-addon": {
     "main": "ember-cli-addon.js"

--- a/tests/broccoli/glimmer-app-test.ts
+++ b/tests/broccoli/glimmer-app-test.ts
@@ -883,7 +883,7 @@ describe('glimmer-app', function() {
       });
     });
 
-    describe('glimer-ast-plugin', () => {
+    describe('glimmer-ast-plugin', () => {
       it('applies `glimmer-ast-plugin`s discovered in the app registry', async () => {
 
         input.write({

--- a/tests/broccoli/glimmer-app-test.ts
+++ b/tests/broccoli/glimmer-app-test.ts
@@ -970,7 +970,7 @@ describe('glimmer-app', function() {
 });
 
 function evalModule(source: string): any {
-  const wrapper = `(function(exports) { ${source}; return exports; })`;
+  const wrapper = `(function(exports) {\n ${source}\n; return exports; })`;
   const func = eval(wrapper);
   const moduleExports = func({});
 

--- a/tests/broccoli/glimmer-app-test.ts
+++ b/tests/broccoli/glimmer-app-test.ts
@@ -26,7 +26,7 @@ class TestGlimmerApp extends GlimmerApp {
 }
 
 describe('glimmer-app', function() {
-  this.timeout(15000);
+  this.timeout(30000);
 
   let input: TempDir;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,12 +12,10 @@
     "outDir": "dist",
     "strict": true,
     "types": ["mocha","node"],
-    "typeRoots": ["node_modules/@types"],
     "lib": [
       "dom",
       "es2015"
-    ],
-    "skipLibCheck": true
+    ]
   },
   "include": [
     "lib/**/*.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "lib": [
       "dom",
       "es2015"
-    ]
+    ],
+    "skipLibCheck": true
   },
   "include": [
     "lib/**/*.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -337,6 +337,14 @@
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.1.6.tgz#1eb26c040e3a84205b1008ad55c800e5e8a94e34"
   integrity sha512-CBk7KTZt3FhPsEkYioG6kuCIpWISw+YI8o+3op4+NXwTpvAPxE1ES8+PY8zfaK2L98b1z5oq03UHa4VYpeUxnw==
 
+"@types/chokidar@^1.7.5":
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/@types/chokidar/-/chokidar-1.7.5.tgz#1fa78c8803e035bed6d98e6949e514b133b0c9b6"
+  integrity sha512-PDkSRY7KltW3M60hSBlerxI8SFPXsO3AL/aRVsO4Kh9IHRW74Ih75gUuTd/aE4LSSFqypb10UIX3QzOJwBQMGQ==
+  dependencies:
+    "@types/events" "*"
+    "@types/node" "*"
+
 "@types/estree@*":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
@@ -346,6 +354,11 @@
   version "0.0.38"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.38.tgz#c1be40aa933723c608820a99a373a16d215a1ca2"
   integrity sha512-F/v7t1LwS4vnXuPooJQGBRKRGIoxWUTmA4VHfqjOccFsNDThD5bfUNpITive6s352O7o384wcpEaDV8rHCehDA==
+
+"@types/events@*":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/events/-/events-1.2.0.tgz#81a6731ce4df43619e5c8c945383b3e62a89ea86"
+  integrity sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==
 
 "@types/lodash.defaultsdeep@^4.6.3":
   version "4.6.4"
@@ -363,6 +376,11 @@
   version "2.2.48"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.48.tgz#3523b126a0b049482e1c3c11877460f76622ffab"
   integrity sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==
+
+"@types/node@*":
+  version "10.12.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.1.tgz#da61b64a2930a80fa708e57c45cd5441eb379d5b"
+  integrity sha512-i1sl+WCX2OCHeUi9oi7PiCNUtYFrpWhpcx878vpeq/tlZTKzcFdHePlyFHVbWqeuKN0SRPl/9ZFDSTsfv9h7VQ==
 
 "@types/node@^7.0.18":
   version "7.10.0"
@@ -6128,6 +6146,11 @@ source-map@^0.6.1, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
+source-map@^0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
+  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
 source-map@~0.1.x:
   version "0.1.43"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
@@ -6566,15 +6589,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@~2.7.0:
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.7.2.tgz#2d615a1ef4aee4f574425cdff7026edf81919836"
-  integrity sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==
-
 typescript@~2.8.3:
   version "2.8.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.4.tgz#0b1db68e6bdfb0b767fa2ab642136a35b059b199"
   integrity sha512-IIU5cN1mR5J3z9jjdESJbnxikTrEz3lzAw/D0Tf45jHpBp55nY31UkUvmVHoffCfKHTqJs3fCLPDxknQTTFegQ==
+
+typescript@~3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.4.tgz#c74ef7b3c2da65beff548b903022cb8c3cd997ed"
+  integrity sha512-JZHJtA6ZL15+Q3Dqkbh8iCUmvxD3iJ7ujXS+fVkKnwIVAdHc5BJTDNM0aTrnr2luKulFjU7W+SRhDZvi66Ru7Q==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
so that postprocessTree fires after everything is finished

This fixes #146 and now fingerprinting of public files works again