### PR TITLE
Ensure any top level `tests/` folder is included in testPackage

### DIFF
--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -165,7 +165,7 @@ export default class GlimmerApp extends AbstractBuild {
 
     let packageTreeArray = [this.publicTree(), this.package(appTree)]
 
-    if (this.env !== 'production') {
+    if (this.env !== 'production' && this.trees.tests !== null) {
       packageTreeArray.push(this.testPackage())
     }
 

--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -360,7 +360,7 @@ export default class GlimmerApp extends AbstractBuild {
   }
 
   public testHTMLTree() {
-    let testsTree = this.trees.tests as Tree;
+    let testsTree = this.trees.tests!;
 
     return new Funnel(testsTree, {
       files: [ 'tests/index.html' ],
@@ -487,7 +487,12 @@ export default class GlimmerApp extends AbstractBuild {
       }
     });
 
+    let trees = [jsTree];
     let testHTMLTree = this.testHTMLTree();
+
+    if (this.env === 'test')  {
+      trees.push(testHTMLTree)
+    }
 
     return new MergeTrees([jsTree, testHTMLTree]);
   }

--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -482,7 +482,7 @@ export default class GlimmerApp extends AbstractBuild {
       input: "src/utils/test-helpers/test-helper.js",
       output: {
         format: "umd",
-        file: "index.js",
+        file: "tests/index.js",
         sourcemap: this.options.sourcemaps!.enabled
       }
     });

--- a/lib/interfaces.ts
+++ b/lib/interfaces.ts
@@ -34,6 +34,7 @@ export interface GlimmerAppOptions {
     styles?: Tree | string;
     public?: Tree | string;
     nodeModules?: Tree | string;
+    tests?: Tree | string;
   }
   registry?: Registry;
   rollup?: RollupOptions;

--- a/tests/broccoli/glimmer-app-test.ts
+++ b/tests/broccoli/glimmer-app-test.ts
@@ -495,6 +495,7 @@ describe('glimmer-app', function() {
         'src': {
           'index.ts': 'console.log("foo");',
           'ui': {
+            'index.html': '',
             'components': {
               'foo-bar': {
                 'template.d.ts': 'declare const _d: {}; export default _d;',
@@ -510,22 +511,26 @@ describe('glimmer-app', function() {
             }
           }
         },
+        'tests': {
+          'index.html': 'foo'
+        },
         'config': {},
         'tsconfig.json': tsconfigContents
       });
 
       let app = createApp({
         trees: {
+          tests: 'tests',
           nodeModules: path.join(__dirname, '..', '..', '..', 'node_modules')
         }
       });
       let output = await buildOutput(app.toTree());
-      let actual = output.read();
+      let actual = output.read() as any;
 
       expect(app.env).to.eq('test');
-      expect(actual['index.js'], 'builds src').to.include('console.log("qux")');
-      expect(actual['index.js'], 'builds tests').to.include('console.log(FooBar)');
-      expect(actual['index.js'], 'builds module map which includes the compiled templates').to.include('Hello!');
+      expect(actual.tests['index.js'], 'builds src').to.include('console.log("qux")');
+      expect(actual.tests['index.js'], 'builds tests').to.include('console.log(FooBar)');
+      expect(actual.tests['index.js'], 'builds module map which includes the compiled templates').to.include('Hello!');
     });
   });
 


### PR DESCRIPTION
This resolves https://github.com/glimmerjs/glimmer-application-pipeline/pull/128

However, the Glimmer application blueprint needs to be updated to do a variety of thigns.

- [ ] Must update `testem.js` to point it's `test_page` directive to `dist/tests/index.html`
- [ ] Must update the blueprint dependency on this package
- [ ] Must create a default `tests/index.html` file that conforms to the latest QUnit CDN url (temporarily) and requires the test entry point.