### PR TITLE
Remove linting trees from build

### DIFF
--- a/lib/broccoli/glimmer-app.ts
+++ b/lib/broccoli/glimmer-app.ts
@@ -34,7 +34,7 @@ import {
 
 import maybeDebug from "./utils/maybe-debug";
 import normalizeTree from "./utils/normalize-tree"
-import { addonTreesFor, addonLintTree } from "./utils/addons";
+import { addonTreesFor } from "./utils/addons";
 import RollupWithDependencies from "./rollup-with-dependencies";
 import GlimmerJSONCompiler from './compilers/glimmer-json-compiler';
 import defaultModuleConfiguration from "./default-module-configuration";
@@ -436,13 +436,9 @@ export default class GlimmerApp extends AbstractBuild {
     }
 
     if (this.env !== "production") {
-      const lintTrees = this.lint();
       jsTrees.push(
-        new TestEntrypointBuilder(
-          new MergeTrees([tsTree, ...lintTrees])
-        )
+        new TestEntrypointBuilder(tsTree)
       );
-      jsTrees.push(...lintTrees);
     }
 
     // Merge the JavaScript source and generated module map and resolver
@@ -497,27 +493,6 @@ export default class GlimmerApp extends AbstractBuild {
     }
 
     return new MergeTrees(trees);
-  }
-
-  private lint() {
-    let { src } = this.trees;
-
-    let templateTree = new Funnel(src, {
-      include: ["**/*.hbs"]
-    });
-
-    let srcTree = new Funnel(src, {
-      exclude: ["**/*.hbs"]
-    });
-
-    let lintedTemplates = addonLintTree(
-      this.project,
-      "templates",
-      templateTree
-    );
-    let lintedSrc = addonLintTree(this.project, "src", srcTree);
-
-    return [lintedTemplates, lintedSrc];
   }
 
   private rollupTree(jsTree: Tree, options?: {}): Tree {

--- a/tests/broccoli/glimmer-app-test.ts
+++ b/tests/broccoli/glimmer-app-test.ts
@@ -8,7 +8,6 @@ import { buildOutput, createTempDir, TempDir } from 'broccoli-test-helper';
 const MockCLI = require('ember-cli/tests/helpers/mock-cli');
 const Project = require('ember-cli/lib/models/project');
 const stew = require('broccoli-stew');
-const td = require('testdouble');
 
 const { stripIndent } = require('common-tags');
 
@@ -139,54 +138,6 @@ describe('glimmer-app', function() {
       });
     });
   });
-
-  describe('lintTree', function() {
-    const ORIGINAL_EMBER_ENV = process.env.EMBER_ENV;
-
-    beforeEach(() => {
-      process.env.EMBER_ENV = 'test';
-    });
-
-    afterEach(() => {
-      process.env.EMBER_ENV = ORIGINAL_EMBER_ENV;
-    });
-
-    it('invokes lintTree hook on addons', async function() {
-      input.write({
-        'src': {
-          'index.ts': 'export default {};',
-          'ui': {
-            'index.html': 'src',
-          },
-          'utils': {
-            'test-helpers': {
-              'test-helper.ts': ''
-            }
-          }
-        },
-        'config': {}
-      });
-
-      let lint = td.function('lintTree');
-
-      let app = createApp({
-        trees: {
-          nodeModules: path.join(__dirname, '..', '..', '..', 'node_modules')
-        }
-      }, [
-        {
-          name: 'awesome-linter',
-          lintTree: lint
-        }
-      ]);
-
-      await buildOutput(app.toTree());
-      td.verify(lint('templates', td.matchers.anything()));
-      td.verify(lint('src', td.matchers.anything()));
-
-    });
-
-  }),
 
   describe('publicTree', function() {
     it('includes any files in `public/` in the project', async function() {


### PR DESCRIPTION
This was posed as an RFC to ember-cli and merged (but not implemented.
The idea is that we have standard ways to lint and it complicates (and
slows) our build, so add an `yarn test` command that includes `ember
test && yarn run lint:js && yarn run lint:template`

For reference the RFC is here:

https://github.com/sangm/rfcs/blob/master/active/0000-remove-ember-cli-eslint.md