### PR TITLE
Fixed issue with usage of path in test-entrypoint-builder

### DIFF
--- a/lib/broccoli/test-entrypoint-builder.ts
+++ b/lib/broccoli/test-entrypoint-builder.ts
@@ -23,7 +23,7 @@ export default class TestEntrypointBuilder extends CachingWriterPlugin {
 
     function isTest({ name }: { name: string }) { return name.match(/\-test$/); }
     function asImportStatement({ dir, name }: { dir: string, name: string }) {
-      let testDirRelativePath = `./${path.join(dir, name)}`;
+      let testDirRelativePath = `./${path.posix.join(dir, name)}`;
       return `import '${testDirRelativePath}';\n`;
     }
 


### PR DESCRIPTION
The issue was reported in glimmerjs/glimmer.js (https://github.com/glimmerjs/glimmer.js/issues/130)